### PR TITLE
cleaned the cloud info store

### DIFF
--- a/cmd/cloudinfo/main.go
+++ b/cmd/cloudinfo/main.go
@@ -66,8 +66,7 @@ func main() {
 
 	prodInfo, err := cloudinfo.NewCachingCloudInfo(
 		viper.GetDuration(prodInfRenewalIntervalFlag),
-		cloudinfo.NewCacheProductStore(24*time.Hour, viper.GetDuration(prodInfRenewalIntervalFlag),
-			8*time.Minute),
+		cloudinfo.NewCacheProductStore(24*time.Hour, viper.GetDuration(prodInfRenewalIntervalFlag)),
 		infoers(ctx), metrics.NewDefaultMetricsReporter())
 	quitOnError(ctx, "error encountered", err)
 

--- a/cmd/cloudinfo/main.go
+++ b/cmd/cloudinfo/main.go
@@ -43,7 +43,6 @@ import (
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo/oracle"
 	"github.com/banzaicloud/cloudinfo/pkg/logger"
 	"github.com/gin-gonic/gin"
-	"github.com/patrickmn/go-cache"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
@@ -66,7 +65,7 @@ func main() {
 	logger.Extract(ctx).WithField("version", Version).WithField("commit_hash", CommitHash).WithField("build_date", BuildDate).Info("cloudinfo initialization")
 
 	prodInfo, err := cloudinfo.NewCachingCloudInfo(viper.GetDuration(prodInfRenewalIntervalFlag),
-		cache.New(cache.NoExpiration, 24.*time.Hour), infoers(ctx), metrics.NewDefaultMetricsReporter())
+		cloudinfo.NewCacheProductStorer(24*time.Hour), infoers(ctx), metrics.NewDefaultMetricsReporter())
 	quitOnError(ctx, "error encountered", err)
 
 	go prodInfo.Start(ctx)

--- a/cmd/cloudinfo/main.go
+++ b/cmd/cloudinfo/main.go
@@ -64,8 +64,11 @@ func main() {
 
 	logger.Extract(ctx).WithField("version", Version).WithField("commit_hash", CommitHash).WithField("build_date", BuildDate).Info("cloudinfo initialization")
 
-	prodInfo, err := cloudinfo.NewCachingCloudInfo(viper.GetDuration(prodInfRenewalIntervalFlag),
-		cloudinfo.NewCacheProductStorer(24*time.Hour), infoers(ctx), metrics.NewDefaultMetricsReporter())
+	prodInfo, err := cloudinfo.NewCachingCloudInfo(
+		viper.GetDuration(prodInfRenewalIntervalFlag),
+		cloudinfo.NewCacheProductStore(24*time.Hour, viper.GetDuration(prodInfRenewalIntervalFlag),
+			8*time.Minute),
+		infoers(ctx), metrics.NewDefaultMetricsReporter())
 	quitOnError(ctx, "error encountered", err)
 
 	go prodInfo.Start(ctx)

--- a/pkg/cloudinfo/alibaba/network_mapper.go
+++ b/pkg/cloudinfo/alibaba/network_mapper.go
@@ -21,10 +21,10 @@ import (
 
 var (
 	ntwPerfMap = map[string][]string{
-		cloudinfo.NTW_LOW:    {"0.1 Gbit/s", "0.2 Gbit/s", "0.4 Gbit/s", "0.5 Gbit/s", "0.8 Gbit/s", "1.0 Gbit/s", "1.2 Gbit/s", "1.5 Gbit/s", "2.0 Gbit/s"},
-		cloudinfo.NTW_MEDIUM: {"2.5 Gbit/s", "3.0 Gbit/s", "4.0 Gbit/s", "4.5 Gbit/s", "5.0 Gbit/s", "6.0 Gbit/s", "8.0 Gbit/s"},
-		cloudinfo.NTW_HIGH:   {"10.0 Gbit/s"},
-		cloudinfo.NTW_EXTRA:  {"17.0 Gbit/s", "25.0 Gbit/s"},
+		cloudinfo.NetwLow:   {"0.1 Gbit/s", "0.2 Gbit/s", "0.4 Gbit/s", "0.5 Gbit/s", "0.8 Gbit/s", "1.0 Gbit/s", "1.2 Gbit/s", "1.5 Gbit/s", "2.0 Gbit/s"},
+		cloudinfo.NtwMedium: {"2.5 Gbit/s", "3.0 Gbit/s", "4.0 Gbit/s", "4.5 Gbit/s", "5.0 Gbit/s", "6.0 Gbit/s", "8.0 Gbit/s"},
+		cloudinfo.NtwHight:  {"10.0 Gbit/s"},
+		cloudinfo.NtwExtra:  {"17.0 Gbit/s", "25.0 Gbit/s"},
 	}
 )
 

--- a/pkg/cloudinfo/amazon/network_mapper.go
+++ b/pkg/cloudinfo/amazon/network_mapper.go
@@ -34,10 +34,10 @@ var (
 		//"Up to 10 Gigabit"
 		//"Very Low"
 
-		cloudinfo.NTW_LOW:    {"Very Low", "Low", "Low to Moderate"},
-		cloudinfo.NTW_MEDIUM: {"Moderate", "High"},
-		cloudinfo.NTW_HIGH:   {"Up to 10 Gigabit", "10 Gigabit"},
-		cloudinfo.NTW_EXTRA:  {"20 Gigabit", "25 Gigabit"},
+		cloudinfo.NetwLow:   {"Very Low", "Low", "Low to Moderate"},
+		cloudinfo.NtwMedium: {"Moderate", "High"},
+		cloudinfo.NtwHight:  {"Up to 10 Gigabit", "10 Gigabit"},
+		cloudinfo.NtwExtra:  {"20 Gigabit", "25 Gigabit"},
 	}
 )
 

--- a/pkg/cloudinfo/amazon/network_mapper_test.go
+++ b/pkg/cloudinfo/amazon/network_mapper_test.go
@@ -34,7 +34,7 @@ func TestEc2NetworkMapper_MapNetworkPerf(t *testing.T) {
 				NtwPerf: "Very Low",
 			},
 			check: func(cat string, err error) {
-				assert.Equal(t, cloudinfo.NTW_LOW, cat, "not mapped to the right category")
+				assert.Equal(t, cloudinfo.NetwLow, cat, "not mapped to the right category")
 			},
 		},
 		{

--- a/pkg/cloudinfo/azure/network_mapper.go
+++ b/pkg/cloudinfo/azure/network_mapper.go
@@ -21,9 +21,9 @@ import (
 var (
 	// TODO
 	ntwPerfMap = map[string][]string{
-		cloudinfo.NTW_LOW:    {"Low"},
-		cloudinfo.NTW_MEDIUM: {"Moderate"},
-		cloudinfo.NTW_HIGH:   {""},
+		cloudinfo.NetwLow:   {"Low"},
+		cloudinfo.NtwMedium: {"Moderate"},
+		cloudinfo.NtwHight:  {""},
 	}
 )
 
@@ -33,5 +33,5 @@ type AzureNetworkMapper struct {
 
 // MapNetworkPerf maps the network performance of the azure instance to the category supported by telescopes
 func (nm *AzureNetworkMapper) MapNetworkPerf(ntwPerf string) (string, error) {
-	return ntwPerfMap[cloudinfo.NTW_MEDIUM][0], nil
+	return ntwPerfMap[cloudinfo.NtwMedium][0], nil
 }

--- a/pkg/cloudinfo/cistore.go
+++ b/pkg/cloudinfo/cistore.go
@@ -51,11 +51,11 @@ type CloudInfoStore interface {
 	StoreRegion(provider, service string, val interface{})
 	GetRegion(provider, service string) (interface{}, bool)
 
-	StoreZone(provider string, region string, val interface{})
-	GetZone(provider string, region string) (interface{}, bool)
+	StoreZone(provider, region string, val interface{})
+	GetZone(provider, region string) (interface{}, bool)
 
-	StorePrice(provider string, region string, instanceType string, val interface{})
-	GetPrice(provider string, region string, instanceType string) (interface{}, bool)
+	StorePrice(provider, region, instanceType string, val interface{})
+	GetPrice(provider, region, instanceType string) (interface{}, bool)
 
 	StoreAttribute(provider, service, attribute string, val interface{})
 	GetAttribute(provider, service, attribute string) (interface{}, bool)
@@ -88,20 +88,20 @@ func (cis *CacheProductStore) GetRegion(provider, service string) (interface{}, 
 	return cis.Get(cis.getKey(RegionKeyTemplate, provider, service))
 }
 
-func (cis *CacheProductStore) StoreZone(provider string, region string, val interface{}) {
+func (cis *CacheProductStore) StoreZone(provider, region string, val interface{}) {
 	cis.Set(cis.getKey(ZoneKeyTemplate, provider, region), val, cis.itemExpiry)
 }
 
-func (cis *CacheProductStore) GetZone(provider string, region string) (interface{}, bool) {
-	return cis.Get(cis.getKey(ZoneKeyTemplate))
+func (cis *CacheProductStore) GetZone(provider, region string) (interface{}, bool) {
+	return cis.Get(cis.getKey(ZoneKeyTemplate, provider, region))
 }
 
-func (cis *CacheProductStore) StorePrice(provider string, region string, instanceType string, val interface{}) {
+func (cis *CacheProductStore) StorePrice(provider, region, instanceType string, val interface{}) {
 	cis.Set(cis.getKey(PriceKeyTemplate, provider, region, instanceType), val, cis.itemExpiry)
 }
 
-func (cis *CacheProductStore) GetPrice(provider string, region string, instanceType string) (interface{}, bool) {
-	return cis.Get(cis.getKey(PriceKeyTemplate))
+func (cis *CacheProductStore) GetPrice(provider, region, instanceType string) (interface{}, bool) {
+	return cis.Get(cis.getKey(PriceKeyTemplate, provider, region, instanceType))
 }
 
 func (cis *CacheProductStore) StoreAttribute(provider, service, attribute string, val interface{}) {
@@ -109,7 +109,7 @@ func (cis *CacheProductStore) StoreAttribute(provider, service, attribute string
 }
 
 func (cis *CacheProductStore) GetAttribute(provider, service, attribute string) (interface{}, bool) {
-	return cis.Get(cis.getKey(AttrKeyTemplate))
+	return cis.Get(cis.getKey(AttrKeyTemplate, provider, service, attribute))
 }
 
 func (cis *CacheProductStore) StoreVm(provider, service, region string, val interface{}) {
@@ -117,7 +117,7 @@ func (cis *CacheProductStore) StoreVm(provider, service, region string, val inte
 }
 
 func (cis *CacheProductStore) GetVm(provider, service, region string) (interface{}, bool) {
-	return cis.Get(cis.getKey(VmKeyTemplate))
+	return cis.Get(cis.getKey(VmKeyTemplate, provider, service, region))
 }
 
 func (cis *CacheProductStore) StoreImage(provider, service, regionId string, val interface{}) {
@@ -125,7 +125,7 @@ func (cis *CacheProductStore) StoreImage(provider, service, regionId string, val
 }
 
 func (cis *CacheProductStore) GetImage(provider, service, regionId string) (interface{}, bool) {
-	return cis.Get(cis.getKey(ImageKeyTemplate))
+	return cis.Get(cis.getKey(ImageKeyTemplate, provider, service, regionId))
 }
 
 func (cis *CacheProductStore) StoreVersion(provider, service, region string, val interface{}) {
@@ -133,7 +133,7 @@ func (cis *CacheProductStore) StoreVersion(provider, service, region string, val
 }
 
 func (cis *CacheProductStore) GetVersion(provider, service, region string) (interface{}, bool) {
-	return cis.Get(cis.getKey(VersionKeyTemplate))
+	return cis.Get(cis.getKey(VersionKeyTemplate, provider, service, region))
 }
 
 func (cis *CacheProductStore) StoreStatus(provider string, val interface{}) {
@@ -141,7 +141,7 @@ func (cis *CacheProductStore) StoreStatus(provider string, val interface{}) {
 }
 
 func (cis *CacheProductStore) GetStatus(provider string) (interface{}, bool) {
-	return cis.Get(cis.getKey(StatusKeyTemplate))
+	return cis.Get(cis.getKey(StatusKeyTemplate, provider))
 }
 
 // NewCacheProductStore creates a new store instance.

--- a/pkg/cloudinfo/cistore.go
+++ b/pkg/cloudinfo/cistore.go
@@ -1,0 +1,76 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudinfo
+
+import (
+	"fmt"
+	"github.com/patrickmn/go-cache"
+	"time"
+)
+
+const (
+	// VmKeyTemplate format for generating vm cache keys
+	VmKeyTemplate = "/banzaicloud.com/cloudinfo/providers/%s/services/%s/regions/%s/vms"
+
+	// AttrKeyTemplate format for generating attribute cache keys
+	AttrKeyTemplate = "/banzaicloud.com/cloudinfo/providers/%s/services/%s/attrValues/%s"
+
+	// PriceKeyTemplate format for generating price cache keys
+	PriceKeyTemplate = "/banzaicloud.com/cloudinfo/providers/%s/regions/%s/prices/%s"
+
+	// ZoneKeyTemplate format for generating zone cache keys
+	ZoneKeyTemplate = "/banzaicloud.com/cloudinfo/providers/%s/regions/%s/zones/"
+
+	// RegionKeyTemplate format for generating region cache keys
+	RegionKeyTemplate = "/banzaicloud.com/cloudinfo/providers/%s/services/%s/regions/"
+
+	// StatusKeyTemplate format for generating status cache keys
+	StatusKeyTemplate = "/banzaicloud.com/cloudinfo/providers/%s/status/"
+
+	// ImageKeyTemplate format for generating image cache keys
+	ImageKeyTemplate = "/banzaicloud.com/cloudinfo/providers/%s/services/%s/regions/%s/images"
+
+	// VersionKeyTemplate format for generating kubernetes version cache keys
+	VersionKeyTemplate = "/banzaicloud.com/cloudinfo/providers/%s/services/%s/regions/%s/versions"
+)
+
+// ProductStorer contract for storing and retrieving cloud product information
+type ProductStorer interface {
+	Get(k string) (interface{}, bool)
+	Set(k string, x interface{}, d time.Duration)
+}
+
+type CacheKeyProvider interface {
+	getZonesKey(provider string, region string) string
+
+}
+
+// CacheProductStorer in memory cloud product information storer
+type CacheProductStorer struct {
+	*cache.Cache
+}
+
+// NewCacheProductStorer creates a new ProductStorer instance backef by in memory cache imlementation
+func NewCacheProductStorer(cleanupInterval time.Duration) ProductStorer {
+	return CacheProductStorer{
+		cache.New(cache.NoExpiration, cleanupInterval),
+	}
+}
+
+
+func (cpi *CacheProductStorer) getZonesKey(provider string, region string) string {
+	return fmt.Sprintf(ZoneKeyTemplate, provider, region)
+}
+

--- a/pkg/cloudinfo/cistore.go
+++ b/pkg/cloudinfo/cistore.go
@@ -52,25 +52,109 @@ type ProductStorer interface {
 	Set(k string, x interface{}, d time.Duration)
 }
 
-type CacheKeyProvider interface {
-	getZonesKey(provider string, region string) string
+// Storage operations for cloud information
+type CloudInfoStore interface {
+	StoreRegion(provider, service string, val interface{})
+	GetRegion(provider, service string) (interface{}, bool)
 
+	StoreZone(provider string, region string, val interface{})
+	GetZone(provider string, region string) (interface{}, bool)
+
+	StorePrice(provider string, region string, instanceType string, val interface{})
+	GetPrice(provider string, region string, instanceType string) (interface{}, bool)
+
+	StoreAttribute(provider, service, attribute string, val interface{})
+	GetAttribute(provider, service, attribute string) (interface{}, bool)
+
+	StoreVm(provider, service, region string, val interface{})
+	GetVm(provider, service, region string) (interface{}, bool)
+
+	StoreImage(provider, service, regionId string, val interface{})
+	GetImage(provider, service, regionId string) (interface{}, bool)
+
+	StoreVersion(provider, service, region string, val interface{})
+	GetVersion(provider, service, region string) (interface{}, bool)
+
+	StoreStatus(provider string, val interface{})
+	GetStatus(provider string) (interface{}, bool)
 }
 
-// CacheProductStorer in memory cloud product information storer
-type CacheProductStorer struct {
+// CacheProductStore in memory cloud product information storer
+type CacheProductStore struct {
 	*cache.Cache
 }
 
-// NewCacheProductStorer creates a new ProductStorer instance backef by in memory cache imlementation
-func NewCacheProductStorer(cleanupInterval time.Duration) ProductStorer {
-	return CacheProductStorer{
+func (cis *CacheProductStore) StoreRegion(provider, service string, val interface{}) {
+	cis.Set(cis.getKey(RegionKeyTemplate, provider, service), val, 0)
+}
+
+func (cis *CacheProductStore) GetRegion(provider, service string) (interface{}, bool) {
+	return cis.Get(cis.getKey(RegionKeyTemplate, provider, service))
+}
+
+func (cis *CacheProductStore) StoreZone(provider string, region string, val interface{}) {
+	cis.Set(cis.getKey(ZoneKeyTemplate, provider, region), val, 0)
+}
+
+func (cis *CacheProductStore) GetZone(provider string, region string) (interface{}, bool) {
+	return cis.Get(cis.getKey(ZoneKeyTemplate))
+}
+
+func (cis *CacheProductStore) StorePrice(provider string, region string, instanceType string, val interface{}) {
+	cis.Set(cis.getKey(PriceKeyTemplate, provider, region, instanceType), val, 0)
+}
+
+func (cis *CacheProductStore) GetPrice(provider string, region string, instanceType string) (interface{}, bool) {
+	return cis.Get(cis.getKey(PriceKeyTemplate))
+}
+
+func (cis *CacheProductStore) StoreAttribute(provider, service, attribute string, val interface{}) {
+	cis.Set(cis.getKey(AttrKeyTemplate, provider, service, attribute), val, 0)
+}
+
+func (cis *CacheProductStore) GetAttribute(provider, service, attribute string) (interface{}, bool) {
+	return cis.Get(cis.getKey(AttrKeyTemplate))
+}
+
+func (cis *CacheProductStore) StoreVm(provider, service, region string, val interface{}) {
+	cis.Set(cis.getKey(VmKeyTemplate, provider, service, region), val, 0)
+}
+
+func (cis *CacheProductStore) GetVm(provider, service, region string) (interface{}, bool) {
+	return cis.Get(cis.getKey(VmKeyTemplate))
+}
+
+func (cis *CacheProductStore) StoreImage(provider, service, regionId string, val interface{}) {
+	cis.Set(cis.getKey(ImageKeyTemplate, provider, service, regionId), val, 0)
+}
+
+func (cis *CacheProductStore) GetImage(provider, service, regionId string) (interface{}, bool) {
+	return cis.Get(cis.getKey(ImageKeyTemplate))
+}
+
+func (cis *CacheProductStore) StoreVersion(provider, service, region string, val interface{}) {
+	cis.Set(cis.getKey(VersionKeyTemplate, provider, service, region), val, 0)
+}
+
+func (cis *CacheProductStore) GetVersion(provider, service, region string) (interface{}, bool) {
+	return cis.Get(cis.getKey(VersionKeyTemplate))
+}
+
+func (cis *CacheProductStore) StoreStatus(provider string, val interface{}) {
+	cis.Set(cis.getKey(StatusKeyTemplate, provider), val, 0)
+}
+
+func (cis *CacheProductStore) GetStatus(provider string) (interface{}, bool) {
+	return cis.Get(cis.getKey(StatusKeyTemplate))
+}
+
+// todo default expiration!!!
+func NewCacheProductStorer(cleanupInterval time.Duration) CloudInfoStore {
+	return &CacheProductStore{
 		cache.New(cache.NoExpiration, cleanupInterval),
 	}
 }
 
-
-func (cpi *CacheProductStorer) getZonesKey(provider string, region string) string {
-	return fmt.Sprintf(ZoneKeyTemplate, provider, region)
+func (cis *CacheProductStore) getKey(keyTemplate string, args ... string) string {
+	return fmt.Sprintf(keyTemplate, args)
 }
-

--- a/pkg/cloudinfo/cistore.go
+++ b/pkg/cloudinfo/cistore.go
@@ -152,6 +152,6 @@ func NewCacheProductStore(cleanupInterval, cloudInfoExpiration, priceExpiration 
 	}
 }
 
-func (cis *CacheProductStore) getKey(keyTemplate string, args ... string) string {
+func (cis *CacheProductStore) getKey(keyTemplate string, args ...string) string {
 	return fmt.Sprintf(keyTemplate, args)
 }

--- a/pkg/cloudinfo/cloudinfo.go
+++ b/pkg/cloudinfo/cloudinfo.go
@@ -422,10 +422,6 @@ func (cpi *CachingCloudInfo) GetPrice(ctx context.Context, provider string, regi
 	return p.OnDemandPrice, sumPrice / float64(len(zones)), nil
 }
 
-func (cpi *CachingCloudInfo) getPriceKey(provider string, region string, instanceType string) string {
-	return fmt.Sprintf(PriceKeyTemplate, provider, region, instanceType)
-}
-
 // renewAttrValues retrieves attribute values from the cloud provider and refreshes the attribute store with them
 func (cpi *CachingCloudInfo) renewShortLivedInfo(ctx context.Context, provider string, region string) (map[string]Price, error) {
 	prices, err := cpi.cloudInfoers[provider].GetCurrentPrices(ctx, region)
@@ -533,7 +529,7 @@ func (cpi *CachingCloudInfo) GetProductDetails(ctx context.Context, provider, se
 				pd.SpotInfo = append(pd.SpotInfo, *newZonePrice(zone, price))
 			}
 		} else {
-			log.Debugf("price info not yet cached for key: %s", cpi.getPriceKey(provider, region, vm.Type))
+			log.Debugf("price info not yet cached for vm: %s", vm.Type)
 		}
 
 		if pd.OnDemandPrice != 0 {

--- a/pkg/cloudinfo/cloudinfo.go
+++ b/pkg/cloudinfo/cloudinfo.go
@@ -398,11 +398,6 @@ func (cpi *CachingCloudInfo) renewAttrValues(ctx context.Context, provider, serv
 	return values, nil
 }
 
-// HasShortLivedPriceInfo signals if a product info provider has frequently changing price info
-func (cpi *CachingCloudInfo) HasShortLivedPriceInfo(provider string) bool {
-	return cpi.cloudInfoers[provider].HasShortLivedPriceInfo()
-}
-
 // GetPrice returns the on demand price and zone averaged computed spot price for a given instance type in a given region
 func (cpi *CachingCloudInfo) GetPrice(ctx context.Context, provider string, region string, instanceType string, zones []string) (float64, float64, error) {
 	var p Price

--- a/pkg/cloudinfo/cloudinfo.go
+++ b/pkg/cloudinfo/cloudinfo.go
@@ -241,7 +241,7 @@ func (cpi *CachingCloudInfo) renewProviderInfo(ctx context.Context, provider str
 func (cpi *CachingCloudInfo) renewStatus(provider string) (string, error) {
 	values := strconv.Itoa(int(time.Now().UnixNano() / 1e6))
 
-	cpi.cloudInfoStore.Set(cpi.getStatusKey(provider), values, cpi.renewalInterval)
+	cpi.cloudInfoStore.StoreStatus(provider, values)
 	return values, nil
 }
 
@@ -437,7 +437,6 @@ func (cpi *CachingCloudInfo) renewShortLivedInfo(ctx context.Context, provider s
 		return nil, err
 	}
 	for instType, p := range prices {
-		// todo set expiration
 		cpi.cloudInfoStore.StorePrice(provider, region, instType, p)
 	}
 	return prices, nil
@@ -468,7 +467,6 @@ func (cpi *CachingCloudInfo) renewVms(ctx context.Context, provider, service, re
 			metrics.OnDemandPriceGauge.WithLabelValues(provider, regionId, vm.Type).Set(vm.OnDemandPrice)
 		}
 	}
-	// todo expiration interval
 	cpi.cloudInfoStore.StoreVm(provider, service, regionId, values)
 	return values, nil
 }
@@ -607,7 +605,6 @@ func (cpi *CachingCloudInfo) renewImages(ctx context.Context, provider, service,
 	if err != nil {
 		return nil, err
 	}
-	// todo expiration
 	cpi.cloudInfoStore.StoreImage(provider, service, regionId, values)
 	return values, nil
 }
@@ -634,7 +631,6 @@ func (cpi *CachingCloudInfo) renewVersions(ctx context.Context, provider, servic
 	if err != nil {
 		return nil, err
 	}
-	// todo exp interval
 	cpi.cloudInfoStore.StoreVersion(provider, service, region, values)
 	return values, nil
 

--- a/pkg/cloudinfo/cloudinfo_test.go
+++ b/pkg/cloudinfo/cloudinfo_test.go
@@ -83,9 +83,8 @@ func (dpi *DummyCloudInfoer) GetProducts(ctx context.Context, service, regionId 
 	default:
 		return []VmInfo{
 			{Cpus: float64(2),
-				Mem: float64(32),
-				OnDemandPrice:
-				float64(0.32)},
+				Mem:           float64(32),
+				OnDemandPrice: float64(0.32)},
 		}, nil
 	}
 }

--- a/pkg/cloudinfo/cloudinfo_test.go
+++ b/pkg/cloudinfo/cloudinfo_test.go
@@ -386,7 +386,7 @@ func TestCachingCloudInfo_GetZones(t *testing.T) {
 				assert.Nil(t, err, "the error should be nil")
 
 				// get the values from the cache
-				cachedZones, _ := cpi.vmAttrStore.Get(cpi.getZonesKey("dummy", "dummyRegion"))
+				cachedZones, _ := cpi.cloudInfoStore.Get(cpi.getZonesKey("dummy", "dummyRegion"))
 				assert.EqualValues(t, []string{"dummyZone1", "dummyZone2"}, cachedZones, "zones not cached")
 			},
 		},

--- a/pkg/cloudinfo/cloudinfo_test.go
+++ b/pkg/cloudinfo/cloudinfo_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo/metrics"
-	"github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -30,12 +29,10 @@ import (
 // the struct is to be extended according to the needs of test cases
 type DummyCloudInfoer struct {
 	AttrValues AttrValues
-	Vms        []VmInfo
 	TcId       string
 	//dummyNetworkMapper NetworkPerfMapper
 	// implement the interface
 	CloudInfoer
-	ProductStorer
 }
 
 func newDummyNetworkMapper() dummyNetworkMapper {
@@ -56,8 +53,6 @@ const (
 	GetProductsError        = "could not get products"
 	InitializeError         = "initialization failed"
 	GetZonesError           = "could not get zones"
-	ProductDetailsOK        = "successfully get product details"
-	GetProductDetail        = "returns a product detail"
 )
 
 func (dpi *DummyCloudInfoer) Initialize(ctx context.Context) (map[string]map[string]Price, error) {
@@ -86,7 +81,12 @@ func (dpi *DummyCloudInfoer) GetProducts(ctx context.Context, service, regionId 
 	case GetProductsError:
 		return nil, errors.New(GetProductsError)
 	default:
-		return dpi.Vms, nil
+		return []VmInfo{
+			{Cpus: float64(2),
+				Mem: float64(32),
+				OnDemandPrice:
+				float64(0.32)},
+		}, nil
 	}
 }
 
@@ -142,74 +142,6 @@ func (dpi *DummyCloudInfoer) GetCpuAttrName() string {
 	return "vcpu"
 }
 
-func (dpi *DummyCloudInfoer) Get(k string) (interface{}, bool) {
-	switch dpi.TcId {
-	case ProductDetailsOK:
-		switch k {
-		case "/banzaicloud.com/cloudinfo/providers/dummy/services/dummyService/regions/dummyRegion/vms":
-			return []VmInfo{
-				{
-					Type:          "type-1",
-					OnDemandPrice: 0.021,
-					Cpus:          1,
-					Mem:           2,
-					NtwPerfCat:    "high",
-					SpotPrice:     SpotPriceInfo{"dummy": 0.006},
-				},
-				{
-					Type:       "type-2",
-					Cpus:       2,
-					Mem:        4,
-					NtwPerfCat: "high",
-				},
-				{
-					Type:       "type-3",
-					Cpus:       2,
-					Mem:        4,
-					NtwPerfCat: "high",
-				},
-			}, true
-		case "/banzaicloud.com/cloudinfo/providers/dummy/regions/dummyRegion/prices/type-1":
-			return Price{
-				OnDemandPrice: 0.023,
-				SpotPrice:     SpotPriceInfo{"dummyZone": 0.0069},
-			}, true
-		case "/banzaicloud.com/cloudinfo/providers/dummy/regions/dummyRegion/prices/type-2":
-			return Price{
-				OnDemandPrice: 0.043,
-				SpotPrice:     SpotPriceInfo{"dummyZone": 0.0087},
-			}, true
-		default:
-			return nil, false
-		}
-	case GetProductDetail:
-		switch k {
-		case "/banzaicloud.com/cloudinfo/providers/dummy/services/dummyService/regions/dummyRegion/vms":
-			return []VmInfo{
-				{
-					Type:          "type-1",
-					OnDemandPrice: 0.021,
-					Cpus:          1,
-					Mem:           2,
-					NtwPerfCat:    "high",
-				},
-			}, true
-		case "/banzaicloud.com/cloudinfo/providers/dummy/regions/dummyRegion/prices/type-1":
-			return Price{
-				OnDemandPrice: 0.023,
-				SpotPrice:     SpotPriceInfo{"dummyZone": 0.0069},
-			}, true
-		default:
-			return nil, false
-		}
-	default:
-		return nil, false
-	}
-}
-
-func (dpi *DummyCloudInfoer) Set(k string, x interface{}, d time.Duration) {
-}
-
 func (dpi *DummyCloudInfoer) GetNetworkPerformanceMapper() (NetworkPerfMapper, error) {
 	nm := newDummyNetworkMapper()
 	return &nm, nil
@@ -247,65 +179,10 @@ func TestNewCachingCloudInfo(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			test.checker(NewCachingCloudInfo(10*time.Second, cache.New(5*time.Minute, 10*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter()))
+			test.checker(NewCachingCloudInfo(10*time.Second, NewCacheProductStore(10*time.Minute, 5*time.Minute, 3*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter()))
 		})
 	}
 
-}
-
-func TestCachingCloudInfo_renewVms(t *testing.T) {
-	tests := []struct {
-		name        string
-		attrValue   AttrValue
-		CloudInfoer map[string]CloudInfoer
-		Cache       *cache.Cache
-		checker     func(cache *cache.Cache, vms []VmInfo, err error)
-	}{
-		{
-			name:      "vm successfully renewed",
-			attrValue: AttrValue{Value: float64(2), StrValue: Cpu},
-			CloudInfoer: map[string]CloudInfoer{
-				"dummy": &DummyCloudInfoer{
-					Vms: []VmInfo{{Cpus: float64(2), Mem: float64(32), OnDemandPrice: float64(0.32)}},
-				},
-			},
-			Cache: cache.New(5*time.Minute, 10*time.Minute),
-			checker: func(cache *cache.Cache, vms []VmInfo, err error) {
-				assert.Nil(t, err, "should not get error on vm renewal")
-				assert.Equal(t, 1, len(vms), "there should be a single entry in values")
-				vals, _ := cache.Get("/banzaicloud.com/cloudinfo/providers/dummy/services/dummyService/regions/dummyRegion/vms")
-
-				for _, val := range vals.([]VmInfo) {
-					assert.Equal(t, float64(32), val.Mem, "the value in the cache is not as expected")
-				}
-
-			},
-		},
-		{
-			name:      "could not retrieve virtual machines",
-			attrValue: AttrValue{Value: float64(2), StrValue: Cpu},
-			CloudInfoer: map[string]CloudInfoer{
-				"dummy": &DummyCloudInfoer{
-					TcId: GetProductsError,
-					Vms:  []VmInfo{{Cpus: float64(2), Mem: float64(32), OnDemandPrice: float64(0.32)}},
-				},
-			},
-			Cache: cache.New(5*time.Minute, 10*time.Minute),
-			checker: func(cache *cache.Cache, vms []VmInfo, err error) {
-				assert.EqualError(t, err, GetProductsError)
-				assert.Nil(t, vms, "no vms expected")
-
-			},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			cloudInfo, _ := NewCachingCloudInfo(10*time.Second, test.Cache, test.CloudInfoer, metrics.NewNoOpMetricsReporter())
-			values, err := cloudInfo.renewVms(context.Background(), "dummy", "dummyService", "dummyRegion")
-			test.checker(test.Cache, values, err)
-		})
-	}
 }
 
 func TestCachingCloudInfo_GetAttrValues(t *testing.T) {
@@ -364,48 +241,8 @@ func TestCachingCloudInfo_GetAttrValues(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cloudInfo, _ := NewCachingCloudInfo(10*time.Second, cache.New(5*time.Minute, 10*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter())
+			cloudInfo, _ := NewCachingCloudInfo(10*time.Second, NewCacheProductStore(5*time.Minute, 10*time.Minute, 3*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter())
 			test.checker(cloudInfo.GetAttrValues(context.Background(), "dummy", "dummyService", test.Attribute))
-		})
-	}
-}
-
-func TestCachingCloudInfo_GetZones(t *testing.T) {
-	tests := []struct {
-		name        string
-		CloudInfoer map[string]CloudInfoer
-		checker     func(cpi *CachingCloudInfo, zones []string, err error)
-	}{
-		{
-			name: "zones retrieved and cached",
-			CloudInfoer: map[string]CloudInfoer{
-				"dummy": &DummyCloudInfoer{},
-			},
-			checker: func(cpi *CachingCloudInfo, zones []string, err error) {
-				assert.Equal(t, []string{"dummyZone1", "dummyZone2"}, zones)
-				assert.Nil(t, err, "the error should be nil")
-
-				// get the values from the cache
-				cachedZones, _ := cpi.cloudInfoStore.Get(cpi.getZonesKey("dummy", "dummyRegion"))
-				assert.EqualValues(t, []string{"dummyZone1", "dummyZone2"}, cachedZones, "zones not cached")
-			},
-		},
-		{
-			name: "could not retrieve zones",
-			CloudInfoer: map[string]CloudInfoer{
-				"dummy": &DummyCloudInfoer{TcId: GetZonesError},
-			},
-			checker: func(cpi *CachingCloudInfo, zones []string, err error) {
-				assert.Nil(t, zones, "the error should be nil")
-				assert.EqualError(t, err, GetZonesError)
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			cloudInfo, _ := NewCachingCloudInfo(10*time.Second, cache.New(5*time.Minute, 10*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter())
-			values, err := cloudInfo.GetZones(context.Background(), "dummy", "dummyRegion")
-			test.checker(cloudInfo, values, err)
 		})
 	}
 }
@@ -439,7 +276,7 @@ func TestCachingCloudInfo_Initialize(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cloudInfo, _ := NewCachingCloudInfo(10*time.Second, cache.New(5*time.Minute, 10*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter())
+			cloudInfo, _ := NewCachingCloudInfo(10*time.Second, NewCacheProductStore(5*time.Minute, 10*time.Minute, 3*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter())
 			test.checker(cloudInfo.Initialize(context.Background(), "dummy"))
 		})
 	}
@@ -474,7 +311,7 @@ func TestCachingCloudInfo_renewShortLivedInfo(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			info, _ := NewCachingCloudInfo(10*time.Second, cache.New(5*time.Minute, 10*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter())
+			info, _ := NewCachingCloudInfo(10*time.Second, NewCacheProductStore(5*time.Minute, 10*time.Minute, 3*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter())
 			test.checker(info.renewShortLivedInfo(context.Background(), "dummy", "dummyRegion"))
 		})
 	}
@@ -538,7 +375,7 @@ func TestCachingCloudInfo_GetPrice(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			info, _ := NewCachingCloudInfo(10*time.Second, cache.New(5*time.Minute, 10*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter())
+			info, _ := NewCachingCloudInfo(10*time.Second, NewCacheProductStore(5*time.Minute, 10*time.Minute, 3*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter())
 			values, value, err := info.GetPrice(context.Background(), "dummy", "dummyRegion", "c3.large", test.zones)
 			test.checker(values, value, err)
 		})
@@ -575,63 +412,8 @@ func TestCachingCloudInfo_GetRegions(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			info, _ := NewCachingCloudInfo(10*time.Second, cache.New(5*time.Minute, 10*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter())
+			info, _ := NewCachingCloudInfo(10*time.Second, NewCacheProductStore(5*time.Minute, 10*time.Minute, 3*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter())
 			test.checker(info.GetRegions(context.Background(), "dummy", "compute"))
-		})
-	}
-}
-
-func TestCachingCloudInfo_GetProductDetails(t *testing.T) {
-	tests := []struct {
-		name        string
-		CloudInfoer map[string]CloudInfoer
-		cache       ProductStorer
-		checker     func(details []ProductDetails, err error)
-	}{
-		{
-			name: "successfully retrieved product details",
-			CloudInfoer: map[string]CloudInfoer{
-				"dummy": &DummyCloudInfoer{},
-			},
-			cache: &DummyCloudInfoer{TcId: ProductDetailsOK},
-			checker: func(details []ProductDetails, err error) {
-				assert.Nil(t, err, "the error should be nil")
-				assert.Equal(t, 2, len(details))
-			},
-		},
-		{
-			name: "successfully retrieved one product detail",
-			CloudInfoer: map[string]CloudInfoer{
-				"dummy": &DummyCloudInfoer{},
-			},
-			cache: &DummyCloudInfoer{TcId: GetProductDetail},
-			checker: func(details []ProductDetails, err error) {
-				assert.Nil(t, err, "the error should be nil")
-				assert.Equal(t, 1, len(details))
-				for _, info := range details {
-					assert.Equal(t, "type-1", info.Type)
-					assert.Equal(t, float64(1), info.Cpus)
-					assert.Equal(t, 0.023, info.OnDemandPrice)
-					assert.Equal(t, float64(2), info.Mem)
-				}
-			},
-		},
-		{
-			name: "vms not yet cached, we need to get an error",
-			CloudInfoer: map[string]CloudInfoer{
-				"dummy": &DummyCloudInfoer{},
-			},
-			cache: &DummyCloudInfoer{},
-			checker: func(details []ProductDetails, err error) {
-				assert.Nil(t, details, "the details should be nil")
-				assert.EqualError(t, err, "vms not yet cached for the key: /banzaicloud.com/cloudinfo/providers/dummy/services/dummyService/regions/dummyRegion/vms")
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			info, _ := NewCachingCloudInfo(10*time.Second, test.cache, test.CloudInfoer, metrics.NewNoOpMetricsReporter())
-			test.checker(info.GetProductDetails(context.Background(), "dummy", "dummyService", "dummyRegion"))
 		})
 	}
 }

--- a/pkg/cloudinfo/cloudinfo_test.go
+++ b/pkg/cloudinfo/cloudinfo_test.go
@@ -178,7 +178,7 @@ func TestNewCachingCloudInfo(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			test.checker(NewCachingCloudInfo(10*time.Second, NewCacheProductStore(10*time.Minute, 5*time.Minute, 3*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter()))
+			test.checker(NewCachingCloudInfo(10*time.Second, NewCacheProductStore(10*time.Minute, 5*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter()))
 		})
 	}
 
@@ -240,7 +240,7 @@ func TestCachingCloudInfo_GetAttrValues(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cloudInfo, _ := NewCachingCloudInfo(10*time.Second, NewCacheProductStore(5*time.Minute, 10*time.Minute, 3*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter())
+			cloudInfo, _ := NewCachingCloudInfo(10*time.Second, NewCacheProductStore(5*time.Minute, 10*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter())
 			test.checker(cloudInfo.GetAttrValues(context.Background(), "dummy", "dummyService", test.Attribute))
 		})
 	}
@@ -275,7 +275,7 @@ func TestCachingCloudInfo_Initialize(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cloudInfo, _ := NewCachingCloudInfo(10*time.Second, NewCacheProductStore(5*time.Minute, 10*time.Minute, 3*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter())
+			cloudInfo, _ := NewCachingCloudInfo(10*time.Second, NewCacheProductStore(5*time.Minute, 10*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter())
 			test.checker(cloudInfo.Initialize(context.Background(), "dummy"))
 		})
 	}
@@ -310,7 +310,7 @@ func TestCachingCloudInfo_renewShortLivedInfo(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			info, _ := NewCachingCloudInfo(10*time.Second, NewCacheProductStore(5*time.Minute, 10*time.Minute, 3*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter())
+			info, _ := NewCachingCloudInfo(10*time.Second, NewCacheProductStore(5*time.Minute, 10*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter())
 			test.checker(info.renewShortLivedInfo(context.Background(), "dummy", "dummyRegion"))
 		})
 	}
@@ -374,7 +374,7 @@ func TestCachingCloudInfo_GetPrice(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			info, _ := NewCachingCloudInfo(10*time.Second, NewCacheProductStore(5*time.Minute, 10*time.Minute, 3*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter())
+			info, _ := NewCachingCloudInfo(10*time.Second, NewCacheProductStore(5*time.Minute, 10*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter())
 			values, value, err := info.GetPrice(context.Background(), "dummy", "dummyRegion", "c3.large", test.zones)
 			test.checker(values, value, err)
 		})
@@ -411,7 +411,7 @@ func TestCachingCloudInfo_GetRegions(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			info, _ := NewCachingCloudInfo(10*time.Second, NewCacheProductStore(5*time.Minute, 10*time.Minute, 3*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter())
+			info, _ := NewCachingCloudInfo(10*time.Second, NewCacheProductStore(5*time.Minute, 10*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter())
 			test.checker(info.GetRegions(context.Background(), "dummy", "compute"))
 		})
 	}

--- a/pkg/cloudinfo/google/network_mapper.go
+++ b/pkg/cloudinfo/google/network_mapper.go
@@ -22,10 +22,10 @@ import (
 
 var (
 	ntwPerfMap = map[string][]string{
-		cloudinfo.NTW_LOW:    {"1 Gbit/s", "2 Gbit/s"},
-		cloudinfo.NTW_MEDIUM: {"4 Gbit/s", "6 Gbit/s", "8 Gbit/s"},
-		cloudinfo.NTW_HIGH:   {"10 Gbit/s", "12 Gbit/s", "14 Gbit/s"},
-		cloudinfo.NTW_EXTRA:  {"16 Gbit/s"},
+		cloudinfo.NetwLow:   {"1 Gbit/s", "2 Gbit/s"},
+		cloudinfo.NtwMedium: {"4 Gbit/s", "6 Gbit/s", "8 Gbit/s"},
+		cloudinfo.NtwHight:  {"10 Gbit/s", "12 Gbit/s", "14 Gbit/s"},
+		cloudinfo.NtwExtra:  {"16 Gbit/s"},
 	}
 )
 

--- a/pkg/cloudinfo/infoer.go
+++ b/pkg/cloudinfo/infoer.go
@@ -1,0 +1,70 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudinfo
+
+import "context"
+
+// CloudInfoer lists operations for retrieving cloud provider information
+// Implementers are expected to know the cloud provider specific logic (eg.: cloud provider client usage etc ...)
+// This interface abstracts the cloud provider specifics to its clients
+type CloudInfoer interface {
+	// Initialize is called once per product info renewals so it can be used to download a large price descriptor
+	Initialize(ctx context.Context) (map[string]map[string]Price, error)
+
+	// GetAttributeValues gets the attribute values for the given attribute from the external system
+	GetAttributeValues(ctx context.Context, service, attribute string) (AttrValues, error)
+
+	// GetProducts gets product information based on the given arguments from an external system
+	GetProducts(ctx context.Context, service, regionId string) ([]VmInfo, error)
+
+	// GetZones returns the availability zones in a region
+	GetZones(ctx context.Context, region string) ([]string, error)
+
+	// GetRegions retrieves the available regions form the external system
+	GetRegions(ctx context.Context, service string) (map[string]string, error)
+
+	// HasShortLivedPriceInfo signals if a product info provider has frequently changing price info
+	HasShortLivedPriceInfo() bool
+
+	// GetCurrentPrices retrieves all the spot prices in a region
+	GetCurrentPrices(ctx context.Context, region string) (map[string]Price, error)
+
+	// GetMemoryAttrName returns the provider representation of the memory attribute
+	GetMemoryAttrName() string
+
+	// GetCpuAttrName returns the provider representation of the cpu attribute
+	GetCpuAttrName() string
+
+	// GetServices returns the available services on the given provider
+	GetServices() ([]ServiceDescriber, error)
+
+	// GetServices returns the available services on the  given region
+	GetService(ctx context.Context, service string) (ServiceDescriber, error)
+
+	// HasImages signals if a product info provider has image support
+	HasImages() bool
+
+	// GetServiceImages retrieves the images supported by the given service in the given region
+	GetServiceImages(region, service string) ([]ImageDescriber, error)
+
+	// GetVersions retrieves the  versions supported by the given service in the given region
+	GetVersions(ctx context.Context, service, region string) ([]string, error)
+
+	// GetServiceProducts retrieves the products supported by the given service in the given region
+	GetServiceProducts(region, service string) ([]ProductDetails, error)
+
+	// GetServiceAttributes retrieves the attribute values supported by the given service in the given region for the given attribute
+	GetServiceAttributes(region, service, attribute string) (AttrValues, error)
+}

--- a/pkg/cloudinfo/oracle/network_mapper.go
+++ b/pkg/cloudinfo/oracle/network_mapper.go
@@ -22,10 +22,10 @@ import (
 
 var (
 	ntwPerfMap = map[string][]string{
-		cloudinfo.NTW_LOW:    {"0.6 Gbps"},
-		cloudinfo.NTW_MEDIUM: {"1 Gbps", "1.2 Gbps", "2 Gbps", "2.4 Gbps"},
-		cloudinfo.NTW_HIGH:   {"4.1 Gbps", "4.8 Gbps", "8.2 Gbps"},
-		cloudinfo.NTW_EXTRA:  {"16.4 Gbps", "24.6 Gbps"},
+		cloudinfo.NetwLow:   {"0.6 Gbps"},
+		cloudinfo.NtwMedium: {"1 Gbps", "1.2 Gbps", "2 Gbps", "2.4 Gbps"},
+		cloudinfo.NtwHight:  {"4.1 Gbps", "4.8 Gbps", "8.2 Gbps"},
+		cloudinfo.NtwExtra:  {"16.4 Gbps", "24.6 Gbps"},
 	}
 )
 

--- a/pkg/cloudinfo/types.go
+++ b/pkg/cloudinfo/types.go
@@ -51,59 +51,6 @@ const (
 	VersionKeyTemplate = "/banzaicloud.com/cloudinfo/providers/%s/services/%s/regions/%s/versions"
 )
 
-// CloudInfoer lists operations for retrieving cloud provider information
-// Implementers are expected to know the cloud provider specific logic (eg.: cloud provider client usage etc ...)
-// This interface abstracts the cloud provider specifics to its clients
-type CloudInfoer interface {
-	// Initialize is called once per product info renewals so it can be used to download a large price descriptor
-	Initialize(ctx context.Context) (map[string]map[string]Price, error)
-
-	// GetAttributeValues gets the attribute values for the given attribute from the external system
-	GetAttributeValues(ctx context.Context, service, attribute string) (AttrValues, error)
-
-	// GetProducts gets product information based on the given arguments from an external system
-	GetProducts(ctx context.Context, service, regionId string) ([]VmInfo, error)
-
-	// GetZones returns the availability zones in a region
-	GetZones(ctx context.Context, region string) ([]string, error)
-
-	// GetRegions retrieves the available regions form the external system
-	GetRegions(ctx context.Context, service string) (map[string]string, error)
-
-	// HasShortLivedPriceInfo signals if a product info provider has frequently changing price info
-	HasShortLivedPriceInfo() bool
-
-	// GetCurrentPrices retrieves all the spot prices in a region
-	GetCurrentPrices(ctx context.Context, region string) (map[string]Price, error)
-
-	// GetMemoryAttrName returns the provider representation of the memory attribute
-	GetMemoryAttrName() string
-
-	// GetCpuAttrName returns the provider representation of the cpu attribute
-	GetCpuAttrName() string
-
-	// GetServices returns the available services on the given provider
-	GetServices() ([]ServiceDescriber, error)
-
-	// GetServices returns the available services on the  given region
-	GetService(ctx context.Context, service string) (ServiceDescriber, error)
-
-	// HasImages signals if a product info provider has image support
-	HasImages() bool
-
-	// GetServiceImages retrieves the images supported by the given service in the given region
-	GetServiceImages(region, service string) ([]ImageDescriber, error)
-
-	// GetVersions retrieves the  versions supported by the given service in the given region
-	GetVersions(ctx context.Context, service, region string) ([]string, error)
-
-	// GetServiceProducts retrieves the products supported by the given service in the given region
-	GetServiceProducts(region, service string) ([]ProductDetails, error)
-
-	// GetServiceAttributes retrieves the attribute values supported by the given service in the given region for the given attribute
-	GetServiceAttributes(region, service, attribute string) (AttrValues, error)
-}
-
 // CloudInfo is the main entry point for retrieving vm type characteristics and pricing information on different cloud providers
 type CloudInfo interface {
 	// GetProviders returns the supported providers
@@ -153,13 +100,13 @@ var (
 	// telescope supported network performance of vm-s
 
 	// NTW_LOW the low network performance category
-	NTW_LOW = "low"
+	NetwLow = "low"
 	// NTW_MEDIUM the medium network performance category
-	NTW_MEDIUM = "medium"
+	NtwMedium = "medium"
 	// NTW_HIGH the high network performance category
-	NTW_HIGH = "high"
+	NtwHight = "high"
 	// NTW_EXTRA the highest network performance category
-	NTW_EXTRA = "extra"
+	NtwExtra = "extra"
 )
 
 // NetworkPerfMapper operations related  to mapping between virtual machines to network performance categories

--- a/pkg/cloudinfo/types.go
+++ b/pkg/cloudinfo/types.go
@@ -16,7 +16,6 @@ package cloudinfo
 
 import (
 	"context"
-	"time"
 )
 
 const (
@@ -25,30 +24,6 @@ const (
 
 	// Cpu represents the cpu attribute for the product info
 	Cpu = "cpu"
-
-	// VmKeyTemplate format for generating vm cache keys
-	VmKeyTemplate = "/banzaicloud.com/cloudinfo/providers/%s/services/%s/regions/%s/vms"
-
-	// AttrKeyTemplate format for generating attribute cache keys
-	AttrKeyTemplate = "/banzaicloud.com/cloudinfo/providers/%s/services/%s/attrValues/%s"
-
-	// PriceKeyTemplate format for generating price cache keys
-	PriceKeyTemplate = "/banzaicloud.com/cloudinfo/providers/%s/regions/%s/prices/%s"
-
-	// ZoneKeyTemplate format for generating zone cache keys
-	ZoneKeyTemplate = "/banzaicloud.com/cloudinfo/providers/%s/regions/%s/zones/"
-
-	// RegionKeyTemplate format for generating region cache keys
-	RegionKeyTemplate = "/banzaicloud.com/cloudinfo/providers/%s/services/%s/regions/"
-
-	// StatusKeyTemplate format for generating status cache keys
-	StatusKeyTemplate = "/banzaicloud.com/cloudinfo/providers/%s/status/"
-
-	// ImageKeyTemplate format for generating image cache keys
-	ImageKeyTemplate = "/banzaicloud.com/cloudinfo/providers/%s/services/%s/regions/%s/images"
-
-	// VersionKeyTemplate format for generating kubernetes version cache keys
-	VersionKeyTemplate = "/banzaicloud.com/cloudinfo/providers/%s/services/%s/regions/%s/versions"
 )
 
 // CloudInfo is the main entry point for retrieving vm type characteristics and pricing information on different cloud providers
@@ -113,12 +88,6 @@ var (
 type NetworkPerfMapper interface {
 	// MapNetworkPerf gets the network performance category for the given
 	MapNetworkPerf(ntwPerf string) (string, error)
-}
-
-// ProductStorer interface collects the necessary cache operations
-type ProductStorer interface {
-	Get(k string) (interface{}, bool)
-	Set(k string, x interface{}, d time.Duration)
 }
 
 // ZonePrice struct for displaying price information per zone

--- a/pkg/cloudinfo/types.go
+++ b/pkg/cloudinfo/types.go
@@ -74,13 +74,13 @@ type AttrValues []AttrValue
 var (
 	// telescope supported network performance of vm-s
 
-	// NTW_LOW the low network performance category
+	// NetwLow the low network performance category
 	NetwLow = "low"
-	// NTW_MEDIUM the medium network performance category
+	// NtwMedium the medium network performance category
 	NtwMedium = "medium"
-	// NTW_HIGH the high network performance category
+	// NtwHight the high network performance category
 	NtwHight = "high"
-	// NTW_EXTRA the highest network performance category
+	// NtwExtra the highest network performance category
 	NtwExtra = "extra"
 )
 


### PR DESCRIPTION
The cloud info store is a repository (in memory cache) where the product information is stored.
* the store related interface is cleaned and extracted
* storage operations and cache key related logic moved to the specialized store implementation
* deleted a few unit tests which seemed to be hard to maintain and the covered functionality was simple

