### PR TITLE
configuration  cleanup

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -311,12 +311,23 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:ac139dab09c6fc5e042ce8210d91c2cec106d9d20f24bdf9dba3874a98d79aa6"
+  digest = "1:749bb04f4077e36f539cc90dc2b99a907f4ace8b39760e7d00e19d65732c7440"
   name = "github.com/goph/emperror"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "b1b4a9b847ebc56299eb729faa942b89e9d8a562"
-  version = "v0.14.0"
+  revision = "4cdd86c173cfed1f47be88bd88327140f81bcede"
+  version = "v0.16.0"
+
+[[projects]]
+  digest = "1:36fbc4dc37d6169fa672d7f62c8e899d8de9018d84f9acb692f3415aea475810"
+  name = "github.com/goph/logur"
+  packages = [
+    ".",
+    "adapters/logrusadapter",
+  ]
+  pruneopts = "NUT"
+  revision = "f26f8cefccfb6837e0d36561467cf67d2d0b65b1"
+  version = "v0.9.0"
 
 [[projects]]
   branch = "master"
@@ -351,6 +362,14 @@
   pruneopts = "NUT"
   revision = "ca39e5af3ece67bbcda3d0f4f56a8e24d9f2dad4"
   version = "1.1.3"
+
+[[projects]]
+  digest = "1:4059c14e87a2de3a434430340521b5feece186c1469eff0834c29a63870de3ed"
+  name = "github.com/konsorten/go-windows-terminal-sequences"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "5c8c8bd35d3832f5d134ae1e1e375b69a4d25242"
+  version = "v1.0.1"
 
 [[projects]]
   digest = "1:d244f8666a838fe6ad70ec8fe77f50ebc29fdc3331a2729ba5886bef8435d10d"
@@ -527,12 +546,12 @@
   version = "1.0.1"
 
 [[projects]]
-  digest = "1:6989062eb7ccf25cf38bf4fe3dba097ee209f896cda42cefdca3927047bef7b6"
+  digest = "1:e256b859ab89f005f2f639f5ed9807d0873d9135e27c6382f419b840ff9abe71"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
-  version = "v1.0.5"
+  revision = "e1e72e9de974bd926e5c56f83753fba2df402ce5"
+  version = "v1.3.0"
 
 [[projects]]
   digest = "1:35f36ea322654e3d0932e58ad26556998260b9fa9e691471f756d173684eac0a"
@@ -773,6 +792,8 @@
     "github.com/go-openapi/strfmt",
     "github.com/go-openapi/swag",
     "github.com/goph/emperror",
+    "github.com/goph/logur",
+    "github.com/goph/logur/adapters/logrusadapter",
     "github.com/mitchellh/mapstructure",
     "github.com/moogar0880/problems",
     "github.com/oracle/oci-go-sdk/common",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -13,7 +13,7 @@
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"
-  version = "1.0.4"
+  version = "1.2.0"
 
 [[constraint]]
   name = "github.com/patrickmn/go-cache"
@@ -94,3 +94,11 @@
 [[constraint]]
   name = "github.com/moogar0880/problems"
   version = "0.1.0"
+
+[[constraint]]
+  name = "github.com/goph/logur"
+  version = "0.9.0"
+
+[[constraint]]
+  name = "github.com/goph/emperror"
+  version = "0.16.0"

--- a/cmd/cloudinfo/config.go
+++ b/cmd/cloudinfo/config.go
@@ -22,7 +22,9 @@ import (
 	"github.com/banzaicloud/cloudinfo/internal/platform/log"
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo/alibaba"
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo/amazon"
+	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo/azure"
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo/google"
+	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo/oracle"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
@@ -53,7 +55,12 @@ type Config struct {
 	// Google configuration
 	Google google.Config
 
+	// Alibaba configuration
 	Alibaba alibaba.Config
+
+	Oracle oracle.Config
+
+	Azure azure.Config
 }
 
 // defineFlags defines supported flags and makes them available for viper
@@ -114,6 +121,12 @@ func Configure(v *viper.Viper, pf *pflag.FlagSet) {
 	v.RegisterAlias("alibaba.accesskeyid", alibabaAccessKeyId)
 	v.RegisterAlias("alibaba.accesskeysecret", alibabaAccessKeySecret)
 	v.RegisterAlias("alibaba.regionid", alibabaRegionId)
+
+	// Oracle config
+	v.RegisterAlias("oracle.configlocation", oracleConfigLocation)
+
+	// Azure config
+	v.RegisterAlias("azure.authlocation", azureAuthLocation)
 
 	pf.Init(FriendlyServiceName, pflag.ExitOnError)
 

--- a/cmd/cloudinfo/config.go
+++ b/cmd/cloudinfo/config.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/banzaicloud/cloudinfo/internal/platform/log"
+	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo/alibaba"
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo/amazon"
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo/google"
 	"github.com/spf13/pflag"
@@ -51,6 +52,8 @@ type Config struct {
 
 	// Google configuration
 	Google google.Config
+
+	Alibaba alibaba.Config
 }
 
 // defineFlags defines supported flags and makes them available for viper
@@ -95,7 +98,8 @@ func Configure(v *viper.Viper, pf *pflag.FlagSet) {
 
 	v.RegisterAlias("renewalinterval", prodInfRenewalIntervalFlag)
 
-	v.RegisterAlias("providers", "provider")
+	v.RegisterAlias("providers", providerFlag)
+
 	// Amazon config
 	v.RegisterAlias("amazon.accesskeyid", awsAccessKeyId)
 	v.RegisterAlias("amazon.secretaccesskey", awsSecretAccessKey)
@@ -105,6 +109,11 @@ func Configure(v *viper.Viper, pf *pflag.FlagSet) {
 	//Google config
 	v.RegisterAlias("google.apikey", gceApiKeyFlag)
 	v.RegisterAlias("google.appcredentials", gceApplicationCred)
+
+	// Alibaba config
+	v.RegisterAlias("alibaba.accesskeyid", alibabaAccessKeyId)
+	v.RegisterAlias("alibaba.accesskeysecret", alibabaAccessKeySecret)
+	v.RegisterAlias("alibaba.regionid", alibabaRegionId)
 
 	pf.Init(FriendlyServiceName, pflag.ExitOnError)
 

--- a/cmd/cloudinfo/config.go
+++ b/cmd/cloudinfo/config.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/banzaicloud/cloudinfo/internal/platform/log"
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo/amazon"
+	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo/google"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
@@ -47,6 +48,9 @@ type Config struct {
 
 	// Amazon configuration
 	Amazon amazon.Config
+
+	// Google configuration
+	Google google.Config
 }
 
 // defineFlags defines supported flags and makes them available for viper
@@ -97,6 +101,10 @@ func Configure(v *viper.Viper, pf *pflag.FlagSet) {
 	v.RegisterAlias("amazon.secretaccesskey", awsSecretAccessKey)
 	v.RegisterAlias("amazon.prometheusaddress", prometheusAddressFlag)
 	v.RegisterAlias("amazon.prometheusquery", prometheusQueryFlag)
+
+	//Google config
+	v.RegisterAlias("google.apikey", gceApiKeyFlag)
+	v.RegisterAlias("google.appcredentials", gceApplicationCred)
 
 	pf.Init(FriendlyServiceName, pflag.ExitOnError)
 

--- a/cmd/cloudinfo/config.go
+++ b/cmd/cloudinfo/config.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/banzaicloud/cloudinfo/internal/platform/log"
+	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo/amazon"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
@@ -36,8 +37,16 @@ type Config struct {
 	// Timeout for graceful shutdown
 	ShutdownTimeout time.Duration
 
+	RenewalInterval time.Duration
+
 	// Log configuration
 	Log log.Config
+
+	// providers to be scraped for product information
+	Providers []string
+
+	// Amazon configuration
+	Amazon amazon.Config
 }
 
 // defineFlags defines supported flags and makes them available for viper
@@ -80,6 +89,15 @@ func Configure(v *viper.Viper, pf *pflag.FlagSet) {
 	v.RegisterAlias("log.level", "log-level")
 	v.RegisterAlias("log.noColor", "no_color")
 
+	v.RegisterAlias("renewalinterval", prodInfRenewalIntervalFlag)
+
+	v.RegisterAlias("providers", "provider")
+	// Amazon config
+	v.RegisterAlias("amazon.accesskeyid", awsAccessKeyId)
+	v.RegisterAlias("amazon.secretaccesskey", awsSecretAccessKey)
+	v.RegisterAlias("amazon.prometheusaddress", prometheusAddressFlag)
+	v.RegisterAlias("amazon.prometheusquery", prometheusQueryFlag)
+
 	pf.Init(FriendlyServiceName, pflag.ExitOnError)
 
 	// define flags
@@ -89,8 +107,5 @@ func Configure(v *viper.Viper, pf *pflag.FlagSet) {
 	if err := viper.BindPFlags(pf); err != nil {
 		panic(fmt.Errorf("could not parse flags. error: %s", err))
 	}
-
-	// parse the command line
-	pflag.Parse()
 
 }

--- a/cmd/cloudinfo/config.go
+++ b/cmd/cloudinfo/config.go
@@ -58,8 +58,10 @@ type Config struct {
 	// Alibaba configuration
 	Alibaba alibaba.Config
 
+	// Oracle configuration
 	Oracle oracle.Config
 
+	// Azure configuration
 	Azure azure.Config
 }
 
@@ -99,8 +101,8 @@ func Configure(v *viper.Viper, pf *pflag.FlagSet) {
 	v.AutomaticEnv()
 
 	// Log configuration
-	v.RegisterAlias("log.format", "log-format")
-	v.RegisterAlias("log.level", "log-level")
+	v.RegisterAlias("log.format", logFormatFlag)
+	v.RegisterAlias("log.level", logLevelFlag)
 	v.RegisterAlias("log.noColor", "no_color")
 
 	v.RegisterAlias("renewalinterval", prodInfRenewalIntervalFlag)

--- a/cmd/cloudinfo/main.go
+++ b/cmd/cloudinfo/main.go
@@ -79,9 +79,10 @@ func main() {
 	logur = log.WithFields(logur, map[string]interface{}{"environment": config.Environment, "service": ServiceName})
 
 	logger.Init(logur)
-	ctx := logger.ToContext(context.Background(), logger.NewLogCtxBuilder().WithField("application", "cloudinfo").Build())
+	ctx := logger.ToContext(context.Background(), logger.NewLogCtxBuilder().WithField("application", ServiceName).Build())
 
-	logger.Extract(ctx).Info("initializing the application", map[string]interface{}{"version": Version, "commit_hash": CommitHash, "build_date": BuildDate})
+	logger.Extract(ctx).Info("initializing the application",
+		map[string]interface{}{"version": Version, "commit_hash": CommitHash, "build_date": BuildDate})
 
 	prodInfo, err := cloudinfo.NewCachingCloudInfo(
 		config.RenewalInterval,
@@ -131,9 +132,9 @@ func loadInfoers(ctx context.Context, config Config) map[string]cloudinfo.CloudI
 		case Google:
 			infoer, err = google.NewGoogleInfoer(pctx, config.Google)
 		case Azure:
-			infoer, err = azure.NewAzureInfoer(viper.GetString(azureAuthLocation))
+			infoer, err = azure.NewAzureInfoer(pctx, config.Azure)
 		case Oracle:
-			infoer, err = oracle.NewInfoer(viper.GetString(oracleConfigLocation))
+			infoer, err = oracle.NewOracleInfoer(pctx, config.Oracle)
 		case Alibaba:
 			infoer, err = alibaba.NewAliInfoer(pctx, config.Alibaba)
 		default:

--- a/cmd/cloudinfo/main.go
+++ b/cmd/cloudinfo/main.go
@@ -29,11 +29,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/banzaicloud/cloudinfo/internal/app/cloudinfo/api"
 	"github.com/banzaicloud/cloudinfo/internal/platform/buildinfo"
+	"github.com/banzaicloud/cloudinfo/internal/platform/log"
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo"
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo/alibaba"
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo/amazon"
@@ -43,6 +43,8 @@ import (
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo/oracle"
 	"github.com/banzaicloud/cloudinfo/pkg/logger"
 	"github.com/gin-gonic/gin"
+	"github.com/goph/emperror"
+	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
@@ -57,24 +59,38 @@ func main() {
 		return
 	}
 
-	// initialize the logging framework
-	logger.InitLogger(viper.GetString(logLevelFlag), viper.GetString(logFormatFlag))
+	err := viper.ReadInConfig()
+	_, configFileNotFound := err.(viper.ConfigFileNotFoundError)
+	if !configFileNotFound {
+		emperror.Panic(errors.Wrap(err, "failed to read configuration"))
+	}
 
+	var config Config
+	err = viper.Unmarshal(&config)
+	emperror.Panic(errors.Wrap(err, "failed to unmarshal configuration"))
+
+	// Create logger (first thing after configuration loading)
+	logur := log.NewLogger(config.Log)
+
+	// Provide some basic context to all log lines
+	logur = log.WithFields(logur, map[string]interface{}{"environment": config.Environment, "service": ServiceName})
+
+	logger.Init(logur)
 	ctx := logger.ToContext(context.Background(), logger.NewLogCtxBuilder().WithField("application", "cloudinfo").Build())
 
-	logger.Extract(ctx).WithField("version", Version).WithField("commit_hash", CommitHash).WithField("build_date", BuildDate).Info("cloudinfo initialization")
+	logger.Extract(ctx).Info("cloudinfo initialization", map[string]interface{}{"version": Version, "commit_hash": CommitHash, "build_date": BuildDate})
 
 	prodInfo, err := cloudinfo.NewCachingCloudInfo(
 		viper.GetDuration(prodInfRenewalIntervalFlag),
 		cloudinfo.NewCacheProductStore(24*time.Hour, viper.GetDuration(prodInfRenewalIntervalFlag)),
 		infoers(ctx), metrics.NewDefaultMetricsReporter())
-	quitOnError(ctx, "error encountered", err)
+	emperror.Panic(err)
 
 	go prodInfo.Start(ctx)
 
 	// configure the gin validator
 	err = api.ConfigureValidator(ctx, viper.GetStringSlice(providerFlag), prodInfo)
-	quitOnError(ctx, "error encountered", err)
+	emperror.Panic(err)
 
 	buildInfo := buildinfo.New(Version, CommitHash, BuildDate)
 	routeHandler := api.NewRouteHandler(prodInfo, buildInfo)
@@ -122,21 +138,13 @@ func infoers(ctx context.Context) map[string]cloudinfo.CloudInfoer {
 				viper.GetString(alibabaAccessKeyId),
 				viper.GetString(alibabaAccessKeySecret))
 		default:
-			logger.Extract(pctx).Fatal("provider is not supported")
+			logger.Extract(pctx).Error("provider is not supported")
 		}
 
-		quitOnError(pctx, "could not initialize product info provider", err)
+		emperror.Panic(err)
 
 		infoers[p] = infoer
-		logger.Extract(pctx).Infof("Configured '%s' product info provider", p)
+		logger.Extract(pctx).Info("configured product info provider", map[string]interface{}{"provider": p})
 	}
 	return infoers
-}
-
-func quitOnError(ctx context.Context, msg string, err error) {
-	if err != nil {
-		logger.Extract(ctx).WithError(err).Error(msg)
-		pflag.Usage()
-		os.Exit(-1)
-	}
 }

--- a/cmd/cloudinfo/main.go
+++ b/cmd/cloudinfo/main.go
@@ -135,10 +135,7 @@ func loadInfoers(ctx context.Context, config Config) map[string]cloudinfo.CloudI
 		case Oracle:
 			infoer, err = oracle.NewInfoer(viper.GetString(oracleConfigLocation))
 		case Alibaba:
-			infoer, err = alibaba.NewAlibabaInfoer(
-				viper.GetString(alibabaRegionId),
-				viper.GetString(alibabaAccessKeyId),
-				viper.GetString(alibabaAccessKeySecret))
+			infoer, err = alibaba.NewAliInfoer(pctx, config.Alibaba)
 		default:
 			logger.Extract(pctx).Error("provider is not supported")
 		}

--- a/cmd/cloudinfo/main.go
+++ b/cmd/cloudinfo/main.go
@@ -69,6 +69,7 @@ func main() {
 	}
 
 	var config Config
+	// configuration gets populated here - external configuration sources (flags, env vars) are processed into the instance
 	err = viper.Unmarshal(&config)
 	emperror.Panic(errors.Wrap(err, "failed to unmarshal configuration"))
 

--- a/cmd/cloudinfo/vars.go
+++ b/cmd/cloudinfo/vars.go
@@ -17,7 +17,7 @@ package main
 const (
 	// It identifies the service itself, the actual instance needs to be identified via environment
 	// and other details.
-	//ServiceName = "cloudinfo.service"
+	ServiceName = "cloudinfo"
 
 	// FriendlyServiceName is the visible name of the service.
 	FriendlyServiceName = "Banzai Cloud Cloudinfo Service"

--- a/internal/app/cloudinfo/api/handlers.go
+++ b/internal/app/cloudinfo/api/handlers.go
@@ -494,7 +494,7 @@ func (r *RouteHandler) getAttrValues(ctx context.Context) gin.HandlerFunc {
 			Build())
 
 		log := logger.Extract(ctxLog)
-		log.Infof("getting %s attribute values", pathParams.Attribute)
+		log.Info("retrieving attribute values...", map[string]interface{}{"attribute": pathParams.Attribute})
 
 		attributes, err := r.prod.GetAttrValues(ctxLog, pathParams.Provider, pathParams.Service, pathParams.Attribute)
 		if err != nil {
@@ -502,7 +502,7 @@ func (r *RouteHandler) getAttrValues(ctx context.Context) gin.HandlerFunc {
 				"service [%s], attributes [%s]", pathParams.Provider, pathParams.Service, pathParams.Attribute))
 			return
 		}
-		log.Debugf("successfully retrieved %s attribute values", pathParams.Attribute)
+		log.Info("retrieved attribute values...", map[string]interface{}{"attribute": pathParams.Attribute})
 
 		c.JSON(http.StatusOK, AttributeResponse{pathParams.Attribute, attributes})
 	}

--- a/internal/app/cloudinfo/api/validate.go
+++ b/internal/app/cloudinfo/api/validate.go
@@ -74,17 +74,16 @@ func regionValidator(ctx context.Context, cpi cloudinfo.CloudInfo) validator.Fun
 		log := logger.Extract(ctx)
 		ci, err := cpi.GetInfoer(ctx, currentProvider)
 		if err != nil {
-			log.WithError(err).Error("could not get infoer")
+			log.Error("could not get infoer")
 			return false
 		}
 
 		regions, err := ci.GetRegions(ctx, currentService)
 		if err != nil {
-			log.WithError(err).Error("could not get regions")
+			log.Error("could not get regions")
 			return false
 		}
 
-		log.Debugf("current region: %s, regions: %#v", currentRegion, regions)
 		for reg := range regions {
 			if reg == currentRegion {
 				return true
@@ -110,12 +109,12 @@ func serviceValidator(ctx context.Context, cpi cloudinfo.CloudInfo) validator.Fu
 		log := logger.Extract(ctx)
 		infoer, err := cpi.GetInfoer(ctx, currentProvider)
 		if err != nil {
-			log.WithError(err).Error("could not get infoer")
+			log.Error("could not get infoer")
 			return false
 		}
 		services, err := infoer.GetServices()
 		if err != nil {
-			log.WithError(err).Error("could not get services")
+			log.Error("could not get services")
 			return false
 		}
 

--- a/internal/platform/log/config.go
+++ b/internal/platform/log/config.go
@@ -1,0 +1,28 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+// Config holds details necessary for logging.
+type Config struct {
+	// Format specifies the output log format.
+	// Accepted values are: json, logfmt
+	Format string
+
+	// Level is the minimum log level that should appear on the output.
+	Level string
+
+	// NoColor makes sure that no log output gets colorized.
+	NoColor bool
+}

--- a/internal/platform/log/logger.go
+++ b/internal/platform/log/logger.go
@@ -1,0 +1,54 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package log configures a new logger for an application.
+package log
+
+import (
+	"os"
+
+	"github.com/goph/logur"
+	"github.com/goph/logur/adapters/logrusadapter"
+	"github.com/sirupsen/logrus"
+)
+
+// NewLogger creates a new logger.
+func NewLogger(config Config) logur.Logger {
+	logger := logrus.New()
+
+	logger.SetOutput(os.Stdout)
+	logger.SetFormatter(&logrus.TextFormatter{
+		DisableColors:             config.NoColor,
+		EnvironmentOverrideColors: true,
+	})
+
+	switch config.Format {
+	case "logfmt":
+		// Already the default
+
+	case "json":
+		logger.SetFormatter(&logrus.JSONFormatter{})
+	}
+
+	if level, err := logrus.ParseLevel(config.Level); err == nil {
+		logger.SetLevel(level)
+	}
+
+	return logrusadapter.New(logger)
+}
+
+// WithFields returns a new contextual logger instance with context added to it.
+func WithFields(logger logur.Logger, fields map[string]interface{}) logur.Logger {
+	return logur.WithFields(logger, fields)
+}

--- a/internal/platform/log/standard_logger.go
+++ b/internal/platform/log/standard_logger.go
@@ -1,0 +1,12 @@
+package log
+
+import (
+	"log"
+
+	"github.com/goph/logur"
+)
+
+// NewErrorStandardLogger returns a new standard logger logging on error level.
+func NewErrorStandardLogger(logger logur.Logger) *log.Logger {
+	return logur.NewErrorStandardLogger(logger, "", 0)
+}

--- a/internal/platform/log/standard_logger.go
+++ b/internal/platform/log/standard_logger.go
@@ -1,3 +1,17 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package log
 
 import (

--- a/pkg/cloudinfo/alibaba/cloudinfo.go
+++ b/pkg/cloudinfo/alibaba/cloudinfo.go
@@ -145,7 +145,7 @@ func (e *AlibabaInfoer) getCurrentSpotPrices(ctx context.Context, region string,
 
 			prices, err := e.spotClient(region).DescribeSpotPriceHistory(request)
 			if err != nil {
-				log.WithField("region", region).WithError(err).Errorf("failed to get spot price history for instance type [%s].", values[1])
+				log.Error("failed to get spot price history", map[string]interface{}{"instancetype": values[1]})
 				continue
 			}
 
@@ -164,14 +164,14 @@ func (e *AlibabaInfoer) getCurrentSpotPrices(ctx context.Context, region string,
 			}
 		}
 	}
-	log.WithField("region", region).Debug("finished retrieving spot price data")
+	log.Debug("retrieved spot price data", map[string]interface{}{"region": region})
 	return priceInfo, nil
 }
 
 // GetAttributeValues gets the AttributeValues for the given attribute name
 func (e *AlibabaInfoer) GetAttributeValues(ctx context.Context, service, attribute string) (cloudinfo.AttrValues, error) {
 	log := logger.Extract(ctx)
-	log.WithField("attribute", attribute).Debug("retrieving attribute values")
+	log.Debug("retrieving attribute values", map[string]interface{}{"attribute": attribute})
 
 	values := make(cloudinfo.AttrValues, 0)
 	valueSet := make(map[cloudinfo.AttrValue]interface{})
@@ -221,7 +221,8 @@ func (e *AlibabaInfoer) GetAttributeValues(ctx context.Context, service, attribu
 	for attr := range valueSet {
 		values = append(values, attr)
 	}
-	log.Debugf("found %s values: %v", attribute, values)
+
+	log.Debug("found attribute values", map[string]interface{}{"attribute": attribute, "values": fmt.Sprintf("%v", values)})
 	return values, nil
 }
 
@@ -271,7 +272,7 @@ func (e *AlibabaInfoer) GetProducts(ctx context.Context, service, regionId strin
 						ntwPerf := fmt.Sprintf("%.1f Gbit/s", float64(instanceType.InstanceBandwidthRx)/1024000)
 						ntwPerfCat, err := ntwMapper.MapNetworkPerf(ntwPerf)
 						if err != nil {
-							log.WithError(err).Debug("could not get network performance category")
+							log.Debug("could not get network performance category")
 						}
 
 						onDemandPrice, err := strconv.ParseFloat(price.Price, 64)
@@ -295,7 +296,7 @@ func (e *AlibabaInfoer) GetProducts(ctx context.Context, service, regionId strin
 		}
 	}
 
-	log.Debugf("found vms: %#v", vms)
+	log.Debug("found vms", map[string]interface{}{"vms": fmt.Sprintf("%v", vms)})
 	return vms, nil
 }
 
@@ -349,10 +350,10 @@ func (e *AlibabaInfoer) GetCurrentPrices(ctx context.Context, region string) (ma
 		return nil, err
 	}
 
-	log.WithField("region", region).Debug("getting current spot prices directly from the API")
+	log.Debug("getting current spot prices directly from the API", map[string]interface{}{"region": region})
 	spotPrices, err = e.getCurrentSpotPrices(ctx, region, zones)
 	if err != nil {
-		log.WithField("region", region).WithError(err).Error("could not retrieve current prices.")
+		log.Error("could not retrieve current prices.", map[string]interface{}{"region": region})
 		return nil, err
 	}
 

--- a/pkg/cloudinfo/alibaba/cloudinfo.go
+++ b/pkg/cloudinfo/alibaba/cloudinfo.go
@@ -116,6 +116,10 @@ func NewAlibabaInfoer(regionId, accessKeyId, accessKeySecret string) (*AlibabaIn
 	}, nil
 }
 
+func NewAliInfoer(ctx context.Context, cfg Config) (*AlibabaInfoer, error) {
+	return NewAlibabaInfoer(cfg.RegionId, cfg.AccessKeyId, cfg.AccessKeySecret)
+}
+
 // Initialize is not needed on Alibaba because price info is changing frequently
 func (e *AlibabaInfoer) Initialize(ctx context.Context) (map[string]map[string]cloudinfo.Price, error) {
 	return nil, nil

--- a/pkg/cloudinfo/alibaba/cloudinfo_test.go
+++ b/pkg/cloudinfo/alibaba/cloudinfo_test.go
@@ -17,10 +17,13 @@ package alibaba
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo"
+	"github.com/banzaicloud/cloudinfo/pkg/logger"
+	"github.com/goph/logur"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 //testStruct helps to mock external calls
@@ -318,6 +321,7 @@ func TestAlibabaInfoer_GetProducts(t *testing.T) {
 				t.Fatalf("failed to create cloudinfoer; [%s]", err.Error())
 			}
 
+			logger.Init(logur.NewTestLogger())
 			test.check(cloudInfoer.GetProducts(context.TODO(), "compute", test.region))
 		})
 	}

--- a/pkg/cloudinfo/alibaba/config.go
+++ b/pkg/cloudinfo/alibaba/config.go
@@ -1,0 +1,21 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alibaba
+
+type Config struct {
+	AccessKeyId     string
+	AccessKeySecret string
+	RegionId        string
+}

--- a/pkg/cloudinfo/amazon/cloudinfo.go
+++ b/pkg/cloudinfo/amazon/cloudinfo.go
@@ -101,6 +101,11 @@ func NewEc2Infoer(ctx context.Context, promAddr, pq, awsAccessKeyId, awsSecretAc
 	}, nil
 }
 
+// NewAmazonInfoer builds an infoer instance based on the provided configuration
+func NewAmazonInfoer(ctx context.Context, cfg Config) (*Ec2Infoer, error) {
+	return NewEc2Infoer(ctx, cfg.PrometheusAddress, cfg.PrometheusQuery, cfg.AccessKeyId, cfg.SecretAccessKey)
+}
+
 // Initialize is not needed on EC2 because price info is changing frequently
 func (e *Ec2Infoer) Initialize(ctx context.Context) (map[string]map[string]cloudinfo.Price, error) {
 	return nil, nil

--- a/pkg/cloudinfo/amazon/cloudinfo_test.go
+++ b/pkg/cloudinfo/amazon/cloudinfo_test.go
@@ -17,13 +17,15 @@ package amazon
 import (
 	"context"
 	"errors"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/pricing"
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo"
+	"github.com/banzaicloud/cloudinfo/pkg/logger"
+	"github.com/goph/logur"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -210,6 +212,7 @@ func TestNewEc2Infoer(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
+		logger.Init(logur.NewTestLogger())
 		t.Run(test.name, func(t *testing.T) {
 			test.check(NewEc2Infoer(context.Background(), test.prom, "", "", ""))
 		})

--- a/pkg/cloudinfo/amazon/config.go
+++ b/pkg/cloudinfo/amazon/config.go
@@ -1,0 +1,23 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package amazon
+
+// Config represents configuration for obtaining cloud information from Amazon
+type Config struct {
+	AccessKeyId       string
+	SecretAccessKey   string
+	PrometheusAddress string
+	PrometheusQuery   string
+}

--- a/pkg/cloudinfo/azure/cloudinfo.go
+++ b/pkg/cloudinfo/azure/cloudinfo.go
@@ -107,8 +107,8 @@ type PriceRetriever interface {
 	Get(ctx context.Context, filter string) (result commerce.ResourceRateCardInfo, err error)
 }
 
-// NewAzureInfoer creates a new instance of the Azure infoer
-func NewAzureInfoer(authLocation string) (*AzureInfoer, error) {
+// azureInfoer creates a new instance of the Azure infoer
+func azureInfoer(authLocation string) (*AzureInfoer, error) {
 	err := os.Setenv("AZURE_AUTH_LOCATION", authLocation)
 	if err != nil {
 		return nil, err
@@ -152,6 +152,10 @@ func NewAzureInfoer(authLocation string) (*AzureInfoer, error) {
 		providersClient:     providersClient,
 		containerSvcClient:  &containerServiceClient,
 	}, nil
+}
+
+func NewAzureInfoer(ctx context.Context, cfg Config) (*AzureInfoer, error) {
+	return azureInfoer(cfg.AuthLocation)
 }
 
 type regionParts []string

--- a/pkg/cloudinfo/azure/cloudinfo.go
+++ b/pkg/cloudinfo/azure/cloudinfo.go
@@ -208,7 +208,7 @@ func (a *AzureInfoer) Initialize(ctx context.Context) (map[string]map[string]clo
 		return nil, err
 	}
 
-	log.Debugf("queried regions: %v", regions)
+	log.Debug("retrieved regions", map[string]interface{}{"regions": regions})
 
 	rateCardFilter := "OfferDurableId eq 'MS-AZR-0003p' and Currency eq 'USD' and Locale eq 'en-US' and RegionInfo eq 'US'"
 	result, err := a.rateCardClient.Get(context.TODO(), rateCardFilter)
@@ -220,7 +220,7 @@ func (a *AzureInfoer) Initialize(ctx context.Context) (map[string]map[string]clo
 			if !strings.Contains(*v.MeterSubCategory, "Windows") {
 				region, err := a.toRegionID(*v.MeterRegion, regions)
 				if err != nil {
-					log.WithError(err).Debug()
+					log.Debug(err.Error())
 					continue
 				}
 
@@ -229,7 +229,7 @@ func (a *AzureInfoer) Initialize(ctx context.Context) (map[string]map[string]clo
 				var priceInUsd float64
 
 				if len(v.MeterRates) < 1 {
-					log.WithField("region", *v.MeterRegion).Debugf("%s doesn't have rate info in region %s", *v.MeterSubCategory, *v.MeterRegion)
+					log.Debug("missing rate info", map[string]interface{}{"MeterSubCategory": *v.MeterSubCategory, "region": region})
 					continue
 				}
 				for _, rate := range v.MeterRates {
@@ -250,11 +250,12 @@ func (a *AzureInfoer) Initialize(ctx context.Context) (map[string]map[string]clo
 					}
 
 					allPrices[region][instanceType] = price
-					log.WithField("region", region).Debugf("price info added: [machinetype=%s, price=%v]", instanceType, price)
+					log.Debug("price info added", map[string]interface{}{"region": region, "machineType": instanceType, "price": price})
+
 					mts := a.getMachineTypeVariants(instanceType)
 					for _, mt := range mts {
 						allPrices[region][mt] = price
-						log.WithField("region", region).Debugf("price info added: [machinetype=%s, price=%v]", mt, price)
+						log.Debug("price info added", map[string]interface{}{"region": region, "machineType": mt, "price": price})
 					}
 				}
 			}
@@ -351,7 +352,7 @@ func (a *AzureInfoer) addSuffix(mt string, suffixes ...string) []string {
 func (a *AzureInfoer) GetAttributeValues(ctx context.Context, service, attribute string) (cloudinfo.AttrValues, error) {
 	log := logger.Extract(ctx)
 
-	log.Debugf("getting %s values", attribute)
+	log.Debug("getting attribute values", map[string]interface{}{"attribute": attribute})
 
 	values := make(cloudinfo.AttrValues, 0)
 	valueSet := make(map[cloudinfo.AttrValue]interface{})
@@ -364,7 +365,7 @@ func (a *AzureInfoer) GetAttributeValues(ctx context.Context, service, attribute
 	for region := range regions {
 		vmSizes, err := a.vmSizesClient.List(context.TODO(), region)
 		if err != nil {
-			log.WithField("region", region).WithError(err).Warn("couldn't get VM sizes")
+			log.Warn("failed to retrieve VM sizes", map[string]interface{}{"region": region})
 			continue
 		}
 		switch service {
@@ -410,7 +411,7 @@ func (a *AzureInfoer) GetAttributeValues(ctx context.Context, service, attribute
 		values = append(values, attr)
 	}
 
-	log.Debugf("found %s values: %v", attribute, values)
+	log.Debug("retrieved attribute values", map[string]interface{}{"attribute": attribute, "values": values})
 	return values, nil
 }
 
@@ -451,7 +452,7 @@ func (a *AzureInfoer) GetProducts(ctx context.Context, service, regionId string)
 		}
 	}
 
-	log.Debugf("found vms: %#v", vms)
+	log.Debug("found virtual machineds", map[string]interface{}{"vms": fmt.Sprintf("%#v", vms)})
 	return vms, nil
 }
 
@@ -474,7 +475,7 @@ func (a *AzureInfoer) GetRegions(ctx context.Context, service string) (map[strin
 			allLocations[*loc.DisplayName] = *loc.Name
 		}
 	} else {
-		log.WithError(err).Error("error while retrieving azure locations")
+		log.Error("error while retrieving azure locations")
 		return nil, err
 	}
 
@@ -493,17 +494,17 @@ func (a *AzureInfoer) GetRegions(ctx context.Context, service string) (map[strin
 				if *pr.ResourceType == resourceTypeForAks {
 					for _, displName := range *pr.Locations {
 						if loc, ok := allLocations[displName]; ok {
-							log.WithField("region", loc).Debugf("found supported location. [name, display name] = [%s, %s]", loc, displName)
+							log.Debug("found supported location", map[string]interface{}{"name": loc, "displayname": displName})
 							supLocations[loc] = displName
 						} else {
-							log.Debugf("unsupported location. [name, display name] = [%s, %s]", loc, displName)
+							log.Debug("unsupported location", map[string]interface{}{"name": loc, "displayname": displName})
 						}
 					}
 					break
 				}
 			}
 		} else {
-			log.WithError(err).Errorf("error while retrieving supported locations for provider: %s.", resourceTypeForAks)
+			log.Error("failed to retrieve supported locations", map[string]interface{}{"resource": resourceTypeForAks})
 			return nil, err
 		}
 
@@ -514,17 +515,17 @@ func (a *AzureInfoer) GetRegions(ctx context.Context, service string) (map[strin
 				if *pr.ResourceType == resourceTypeForCompute {
 					for _, displName := range *pr.Locations {
 						if loc, ok := allLocations[displName]; ok {
-							log.WithField("region", loc).Debugf("found supported location. [name, display name] = [%s, %s]", loc, displName)
+							log.Debug("found supported location", map[string]interface{}{"name": loc, "displayname": displName})
 							supLocations[loc] = displName
 						} else {
-							log.Debugf("unsupported location. [name, display name] = [%s, %s]", loc, displName)
+							log.Debug("unsupported location", map[string]interface{}{"name": loc, "displayname": displName})
 						}
 					}
 					break
 				}
 			}
 		} else {
-			log.WithError(err).Errorf("error while retrieving supported locations for provider: %s.", resourceTypeForCompute)
+			log.Error("failed to retrieve supported locations", map[string]interface{}{"resource": resourceTypeForCompute})
 			return nil, err
 		}
 
@@ -568,7 +569,7 @@ func (a *AzureInfoer) GetService(ctx context.Context, service string) (cloudinfo
 	}
 	for _, sd := range svcs {
 		if service == sd.ServiceName() {
-			logger.Extract(ctx).Debugf("found service: %s", service)
+			logger.Extract(ctx).Debug("found service", map[string]interface{}{"service": service})
 			return sd, nil
 		}
 	}

--- a/pkg/cloudinfo/azure/cloudinfo_test.go
+++ b/pkg/cloudinfo/azure/cloudinfo_test.go
@@ -19,14 +19,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/preview/commerce/mgmt/2015-06-01-preview/commerce"
-
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2016-06-01/subscriptions"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
-
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo"
-
+	"github.com/banzaicloud/cloudinfo/pkg/logger"
+	"github.com/goph/logur"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -589,6 +588,7 @@ func TestAzureInfoer_GetProducts(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
+		logger.Init(logur.NewTestLogger())
 		t.Run(test.name, func(t *testing.T) {
 			azureInfoer := AzureInfoer{}
 

--- a/pkg/cloudinfo/azure/config.go
+++ b/pkg/cloudinfo/azure/config.go
@@ -1,0 +1,19 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+type Config struct {
+	AuthLocation string
+}

--- a/pkg/cloudinfo/cloudinfo_test.go
+++ b/pkg/cloudinfo/cloudinfo_test.go
@@ -17,12 +17,14 @@ package cloudinfo
 import (
 	"context"
 	"errors"
-	"github.com/goph/emperror"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo/metrics"
+	"github.com/banzaicloud/cloudinfo/pkg/logger"
+	"github.com/goph/emperror"
+	"github.com/goph/logur"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -243,6 +245,7 @@ func TestCachingCloudInfo_GetAttrValues(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			logger.Init(logur.NewTestLogger())
 			cloudInfo, _ := NewCachingCloudInfo(10*time.Second, NewCacheProductStore(5*time.Minute, 10*time.Minute), test.CloudInfoer, metrics.NewNoOpMetricsReporter())
 			test.checker(cloudInfo.GetAttrValues(context.Background(), "dummy", "dummyService", test.Attribute))
 		})

--- a/pkg/cloudinfo/google/cloudinfo.go
+++ b/pkg/cloudinfo/google/cloudinfo.go
@@ -122,8 +122,6 @@ func (g *GceInfoer) Initialize(ctx context.Context) (map[string]map[string]cloud
 		}
 	}
 
-	log.Debugf("google compute engine service id: %s", compEngId)
-
 	zonesInRegions := make(map[string][]string)
 	regions, err := g.GetRegions(ctx, "compute")
 	if err != nil {
@@ -259,7 +257,7 @@ func (g *GceInfoer) priceFromSku(price map[string]map[string]map[string]float64,
 // Queries the Google Cloud Compute API's machine type list endpoint
 func (g *GceInfoer) GetAttributeValues(ctx context.Context, service, attribute string) (cloudinfo.AttrValues, error) {
 	log := logger.Extract(ctx)
-	log.Debugf("getting %s values", attribute)
+	log.Debug("retrieving attribute values", map[string]interface{}{"attribute": attribute})
 
 	values := make(cloudinfo.AttrValues, 0)
 	valueSet := make(map[cloudinfo.AttrValue]interface{})
@@ -291,7 +289,7 @@ func (g *GceInfoer) GetAttributeValues(ctx context.Context, service, attribute s
 		values = append(values, attr)
 	}
 
-	log.Debugf("found %s values: %v", attribute, values)
+	log.Debug("found attribute values", map[string]interface{}{"attribute": attribute, "values": fmt.Sprintf("%v", values)})
 	return values, nil
 }
 
@@ -299,7 +297,7 @@ func (g *GceInfoer) GetAttributeValues(ctx context.Context, service, attribute s
 // Queries the Google Cloud Compute API's machine type list endpoint and CloudBilling's sku list endpoint
 func (g *GceInfoer) GetProducts(ctx context.Context, service, regionId string) ([]cloudinfo.VmInfo, error) {
 	log := logger.Extract(ctx)
-	log.Debug("getting product info")
+	log.Debug("retrieving product information")
 	var vmsMap = make(map[string]cloudinfo.VmInfo)
 	var ntwPerf uint
 	zones, err := g.GetZones(ctx, regionId)
@@ -323,7 +321,7 @@ func (g *GceInfoer) GetProducts(ctx context.Context, service, regionId string) (
 				ntwMapper := newGceNetworkMapper()
 				ntwPerfCat, err := ntwMapper.MapNetworkPerf(fmt.Sprint(ntwPerf, " Gbit/s"))
 				if err != nil {
-					log.WithError(err).Debug("could not get network performance category")
+					log.Debug("could not get network performance category")
 				}
 				vmsMap[mt.Name] = cloudinfo.VmInfo{
 					Type:       mt.Name,
@@ -345,7 +343,7 @@ func (g *GceInfoer) GetProducts(ctx context.Context, service, regionId string) (
 	for _, vm := range vmsMap {
 		vms = append(vms, vm)
 	}
-	log.Debugf("found vms: %#v", vms)
+	log.Debug("found virtual machines", map[string]interface{}{"vms": fmt.Sprintf("%v", vms)})
 	return vms, nil
 }
 
@@ -366,7 +364,7 @@ func (g *GceInfoer) GetRegions(ctx context.Context, service string) (map[string]
 		regionIdMap[region.Name] = description
 
 	}
-	log.Debugf("regions found: %v", regionIdMap)
+	log.Debug("found regions", map[string]interface{}{"regionidmap": fmt.Sprintf("%v", regionIdMap)})
 	return regionIdMap, nil
 }
 
@@ -387,7 +385,8 @@ func (g *GceInfoer) GetZones(ctx context.Context, region string) ([]string, erro
 	if err != nil {
 		return nil, err
 	}
-	log.Debugf("found zones %s", zones)
+
+	log.Debug("found zones", map[string]interface{}{"zones": fmt.Sprintf("%v", zones)})
 	return zones, nil
 }
 
@@ -427,7 +426,7 @@ func (g *GceInfoer) GetService(ctx context.Context, service string) (cloudinfo.S
 	}
 	for _, sd := range svcs {
 		if service == sd.ServiceName() {
-			logger.Extract(ctx).Debugf("found service: %s", service)
+			logger.Extract(ctx).Debug("found service", map[string]interface{}{"service": service})
 			return sd, nil
 		}
 	}

--- a/pkg/cloudinfo/google/cloudinfo.go
+++ b/pkg/cloudinfo/google/cloudinfo.go
@@ -103,6 +103,10 @@ func NewGceInfoer(appCredentials, apiKey string) (*GceInfoer, error) {
 	}, nil
 }
 
+func NewGoogleInfoer(ctx context.Context, cfg Config) (*GceInfoer, error) {
+	return NewGceInfoer(cfg.AppCredentials, cfg.ApiKey)
+}
+
 // Initialize downloads and parses the SKU list of the Compute Engine service
 func (g *GceInfoer) Initialize(ctx context.Context) (map[string]map[string]cloudinfo.Price, error) {
 	log := logger.Extract(ctx)

--- a/pkg/cloudinfo/google/config.go
+++ b/pkg/cloudinfo/google/config.go
@@ -1,0 +1,20 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+type Config struct {
+	ApiKey         string
+	AppCredentials string
+}

--- a/pkg/cloudinfo/oracle/cloudinfo.go
+++ b/pkg/cloudinfo/oracle/cloudinfo.go
@@ -128,11 +128,10 @@ func (i *Infoer) Initialize(ctx context.Context) (prices map[string]map[string]c
 			price := prices[region][product.Type]
 			price.OnDemandPrice = shapePrice
 			prices[region][product.Type] = price
-			log.WithField("region", region).Debugf("price info added: [machinetype=%s, price=%v]", product.Type, price)
+			log.Debug("price info added", map[string]interface{}{"machinetype": product.Type, "price": price})
 		}
 	}
-
-	log.Debugf("queried zones and regions: %v", zonesInRegions)
+	log.Debug("retrieved zones and regions", map[string]interface{}{"zonesInRegions": fmt.Sprintf("%v", zonesInRegions)})
 
 	return
 }
@@ -141,7 +140,7 @@ func (i *Infoer) Initialize(ctx context.Context) (prices map[string]map[string]c
 func (i *Infoer) GetAttributeValues(ctx context.Context, service, attribute string) (values cloudinfo.AttrValues, err error) {
 	log := logger.Extract(ctx)
 
-	log.Debugf("getting %s values", attribute)
+	log.Debug("retrieving attribute values", map[string]interface{}{"attribute": attribute})
 
 	values = make(cloudinfo.AttrValues, 0)
 	uniquemap := make(map[float64]bool)
@@ -178,7 +177,7 @@ func (i *Infoer) GetAttributeValues(ctx context.Context, service, attribute stri
 		}
 	}
 
-	log.Debugf("found %s values: %v", attribute, values)
+	log.Debug("found attribute values", map[string]interface{}{"attributes": attribute, "values": fmt.Sprintf("%v", values)})
 
 	return values, nil
 }
@@ -234,7 +233,7 @@ func (i *Infoer) GetProducts(ctx context.Context, service, regionId string) (pro
 		ntwMapper := newNetworkMapper()
 		ntwPerfCat, err := ntwMapper.MapNetworkPerf(fmt.Sprint(s.NtwPerf))
 		if err != nil {
-			logger.Extract(ctx).WithError(err).Debug("could not get network performance category")
+			logger.Extract(ctx).Debug("could not get network performance category")
 		}
 
 		products = append(products, cloudinfo.VmInfo{
@@ -253,7 +252,7 @@ func (i *Infoer) GetProducts(ctx context.Context, service, regionId string) (pro
 
 // GetRegions returns a map with available regions
 func (i *Infoer) GetRegions(ctx context.Context, service string) (regions map[string]string, err error) {
-	logger.Extract(ctx).Debug("getting regions")
+	logger.Extract(ctx).Debug("retrieving regions")
 
 	c, err := i.client.NewIdentityClient()
 	if err != nil {
@@ -324,7 +323,7 @@ func (i *Infoer) GetService(ctx context.Context, service string) (cloudinfo.Serv
 	}
 	for _, sd := range svcs {
 		if service == sd.ServiceName() {
-			logger.Extract(ctx).Debugf("found service: %s", service)
+			logger.Extract(ctx).Debug("found service", map[string]interface{}{"service": service})
 			return sd, nil
 		}
 	}

--- a/pkg/cloudinfo/oracle/cloudinfo.go
+++ b/pkg/cloudinfo/oracle/cloudinfo.go
@@ -18,10 +18,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/banzaicloud/cloudinfo/pkg/logger"
-
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo"
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo/oracle/client"
+	"github.com/banzaicloud/cloudinfo/pkg/logger"
 )
 
 // Infoer encapsulates the data and operations needed to access external resources
@@ -83,6 +82,10 @@ func NewInfoer(configFileLocation string) (*Infoer, error) {
 		client:     oci,
 		shapeSpecs: shapeSpecs,
 	}, nil
+}
+
+func NewOracleInfoer(ctx context.Context, cfg Config) (*Infoer, error) {
+	return NewInfoer(cfg.ConfigLocation)
 }
 
 // Initialize downloads and parses the SKU list of the Compute Engine service

--- a/pkg/cloudinfo/oracle/config.go
+++ b/pkg/cloudinfo/oracle/config.go
@@ -1,0 +1,19 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracle
+
+type Config struct {
+	ConfigLocation string
+}

--- a/pkg/cloudinfo/oracle/itra.go
+++ b/pkg/cloudinfo/oracle/itra.go
@@ -53,11 +53,11 @@ func (i *Infoer) GetCloudInfoFromITRA(ctx context.Context, partNumber string) (i
 	}
 
 	if _, ok := i.cloudInfoCache[partNumber]; ok {
-		logger.Extract(ctx).Debugf("getting product info for PN[%s] - from cache", partNumber)
+		logger.Extract(ctx).Debug("getting product info for part number - from cache", map[string]interface{}{"PN": partNumber})
 		return i.cloudInfoCache[partNumber], nil
 	}
 
-	logger.Extract(ctx).Debugf("getting product info for PN[%s]", partNumber)
+	logger.Extract(ctx).Debug("getting product info for PN[%s]", map[string]interface{}{"PN": partNumber})
 
 	url := fmt.Sprintf("https://itra.oraclecloud.com/itas/.anon/myservices/api/v1/products?partNumber=%s", partNumber)
 	resp, err := http.Get(url)

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -16,14 +16,15 @@ package logger
 
 import (
 	"context"
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
-	"reflect"
 	"testing"
+
+	"github.com/goph/logur"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestContextLogger(t *testing.T) {
 
+	Init(logur.NewTestLogger())
 	ctx := ToContext(context.Background(), NewLogCtxBuilder().
 		WithProvider("test-provider").
 		WithRegion("test-region").
@@ -39,60 +40,6 @@ func TestContextLogger(t *testing.T) {
 	}(ctx, done)
 	<-done
 	Extract(ctx).Info("after routine")
-}
-
-func TestInitLogger(t *testing.T) {
-	tests := []struct {
-		name     string
-		logLevel string
-		fmtStr   string
-		checker  func(args ...interface{}) bool
-	}{
-		{
-			name:     "debug log level",
-			logLevel: "debug",
-			fmtStr:   "",
-			checker: func(logArg ...interface{}) bool {
-				level := logArg[1]
-				assert.Equal(t, level, Level())
-				return true
-			},
-		},
-		{
-			name:     "info log level",
-			logLevel: "info",
-			fmtStr:   "",
-			checker: func(logArg ...interface{}) bool {
-				level := logArg[1]
-				assert.Equal(t, level, Level())
-				return true
-			},
-		},
-		{
-			name:     "default log formatter",
-			logLevel: "error",
-			fmtStr:   "",
-			checker: func(logArg ...interface{}) bool {
-				assert.Equal(t, reflect.TypeOf(&logrus.TextFormatter{}).String(), reflect.TypeOf(Formatter()).String())
-				return true
-			},
-		},
-		{
-			name:     "json log formatter",
-			logLevel: "error",
-			fmtStr:   "json",
-			checker: func(logArg ...interface{}) bool {
-				assert.Equal(t, reflect.TypeOf(&logrus.JSONFormatter{}).String(), reflect.TypeOf(Formatter()).String())
-				return true
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			InitLogger(test.logLevel, test.fmtStr)
-			test.checker(Log(), test.logLevel, test.fmtStr)
-		})
-	}
 }
 
 func TestToContext(t *testing.T) {
@@ -131,10 +78,7 @@ func TestToContext(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			InitLogger("debug", "json")
-
 			ctx := ToContext(test.initialContext, test.fields)
-
 			test.check(ctx, test.fields)
 		})
 	}

--- a/pkg/logger/middleware.go
+++ b/pkg/logger/middleware.go
@@ -64,7 +64,7 @@ func Middleware(notlogged ...string) gin.HandlerFunc {
 				fields["correlation-id"] = cid
 			}
 
-			entry := logger.WithFields(fields)
+			entry := logrus.WithFields(fields)
 
 			if len(c.Errors) > 0 {
 				// Append error field if this is an erroneous request.


### PR DESCRIPTION
This PR is part of
* application configuration represented by a dedicated struct (populated by viper from various sources: flags, env ...)
* logging integrated through logur (and properly configured from the configuration)
* removed the non-standard ContextLogger interface; using contextual logging instead
* introduced config struct to manage application configuration
* provider specific infoer configurations separated fro better maintainability - thes are populated through viper during app initialization

relates to #107
