### PR TITLE
Extracted product information gathering logic

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -933,6 +933,7 @@
     "github.com/stretchr/testify/assert",
     "go.opencensus.io/exporter/jaeger",
     "go.opencensus.io/exporter/prometheus",
+    "go.opencensus.io/trace",
     "golang.org/x/net/context",
     "golang.org/x/oauth2/google",
     "google.golang.org/api/cloudbilling/v1",

--- a/cmd/cloudinfo/main.go
+++ b/cmd/cloudinfo/main.go
@@ -106,19 +106,14 @@ func main() {
 
 	reporter := metrics.NewDefaultMetricsReporter()
 
-	prodInfo, err := cloudinfo.NewCachingCloudInfo(
-		config.RenewalInterval,
-		cloudInfoStore,
-		infoers,
-		reporter,
-		tracer)
+	prodInfo, err := cloudinfo.NewCachingCloudInfo(cloudInfoStore, infoers, reporter, tracer)
 
 	emperror.Panic(err)
 
 	scrapingDriver := cloudinfo.NewScrapingDriver(config.RenewalInterval, infoers, cloudInfoStore, logur, reporter, tracer)
-	scrapingDriver.StartScraping(ctx)
 
-	//go prodInfo.Start(ctx)
+	err = scrapingDriver.StartScraping(ctx)
+	emperror.Panic(err)
 
 	// start the management service
 	if config.Management.Enabled {

--- a/cmd/cloudinfo/main.go
+++ b/cmd/cloudinfo/main.go
@@ -79,7 +79,7 @@ func main() {
 	logur := log.NewLogger(config.Log)
 
 	// Provide some basic context to all log lines
-	logur = log.WithFields(logur, map[string]interface{}{"environment": config.Environment, "service": ServiceName})
+	logur = log.WithFields(logur, map[string]interface{}{"environment": config.Environment, "application": ServiceName})
 
 	// inject the configured logger instance
 	logger.Init(logur)

--- a/internal/app/cloudinfo/api/routes.go
+++ b/internal/app/cloudinfo/api/routes.go
@@ -31,13 +31,13 @@ import (
 
 // RouteHandler configures the REST API routes in the gin router
 type RouteHandler struct {
-	prod           *cloudinfo.CachingCloudInfo
+	prod           cloudinfo.CloudInfo
 	buildInfo      buildinfo.BuildInfo
 	errorResponder Responder
 }
 
 // NewRouteHandler creates a new RouteHandler and returns a reference to it
-func NewRouteHandler(p *cloudinfo.CachingCloudInfo, bi buildinfo.BuildInfo) *RouteHandler {
+func NewRouteHandler(p cloudinfo.CloudInfo, bi buildinfo.BuildInfo) *RouteHandler {
 	return &RouteHandler{
 		prod:           p,
 		buildInfo:      bi,

--- a/internal/app/cloudinfo/api/types.go
+++ b/internal/app/cloudinfo/api/types.go
@@ -136,12 +136,8 @@ func NewServiceResponse(sd cloudinfo.ServiceDescriber) ServiceResponse {
 }
 
 // NewServicesResponse assembles a new services response
-func NewServicesResponse(sds []cloudinfo.ServiceDescriber) ServicesResponse {
-	var services []cloudinfo.Service
-	for _, sd := range sds {
-		services = append(services, cloudinfo.NewService(sd.ServiceName()))
-	}
+func NewServicesResponse(sds []cloudinfo.Service) ServicesResponse {
 	return ServicesResponse{
-		Services: services,
+		Services: sds,
 	}
 }

--- a/pkg/cloudinfo/alibaba/cloudinfo.go
+++ b/pkg/cloudinfo/alibaba/cloudinfo.go
@@ -403,8 +403,8 @@ func (p *onDemandPrice) getOnDemandPrice(url string) (OnDemandPrice, error) {
 }
 
 // GetServices returns the available services on the provider
-func (e *AlibabaInfoer) GetServices() ([]cloudinfo.ServiceDescriber, error) {
-	services := []cloudinfo.ServiceDescriber{
+func (e *AlibabaInfoer) GetServices() ([]cloudinfo.Service, error) {
+	services := []cloudinfo.Service{
 		cloudinfo.NewService(svcCompute),
 		cloudinfo.NewService(svcAck)}
 	return services, nil

--- a/pkg/cloudinfo/amazon/cloudinfo.go
+++ b/pkg/cloudinfo/amazon/cloudinfo.go
@@ -527,8 +527,8 @@ func (e *Ec2Infoer) GetCpuAttrName() string {
 }
 
 // GetServices returns the available services on the provider
-func (e *Ec2Infoer) GetServices() ([]cloudinfo.ServiceDescriber, error) {
-	services := []cloudinfo.ServiceDescriber{
+func (e *Ec2Infoer) GetServices() ([]cloudinfo.Service, error) {
+	services := []cloudinfo.Service{
 		cloudinfo.NewService("compute"),
 		cloudinfo.NewService("eks")}
 	return services, nil

--- a/pkg/cloudinfo/amazon/cloudinfo.go
+++ b/pkg/cloudinfo/amazon/cloudinfo.go
@@ -217,8 +217,8 @@ func (e *Ec2Infoer) GetProducts(ctx context.Context, service, regionId string) (
 		}
 		vms = append(vms, vm)
 	}
-	log.Debug("instance types with missing attributes", map[string]interface{}{"missingAttrs": fmt.Sprintf("%v", missingAttributes)})
-	log.Debug("instance types with missing gpu", map[string]interface{}{"missingGPU": fmt.Sprintf("%v", missingGpu)})
+	log.Debug("instance types with missing attributes", map[string]interface{}{"missingAttrs": missingAttributes})
+	log.Debug("instance types with missing gpu", map[string]interface{}{"missingGPU": missingGpu})
 
 	if vms == nil {
 		log.Debug("couldn't find any virtual machines to recommend")

--- a/pkg/cloudinfo/azure/cloudinfo.go
+++ b/pkg/cloudinfo/azure/cloudinfo.go
@@ -558,8 +558,8 @@ func (a *AzureInfoer) GetCpuAttrName() string {
 }
 
 // GetServices returns the available services on the  provider
-func (a *AzureInfoer) GetServices() ([]cloudinfo.ServiceDescriber, error) {
-	services := []cloudinfo.ServiceDescriber{
+func (a *AzureInfoer) GetServices() ([]cloudinfo.Service, error) {
+	services := []cloudinfo.Service{
 		cloudinfo.NewService("compute"),
 		cloudinfo.NewService("aks")}
 	return services, nil

--- a/pkg/cloudinfo/cistore.go
+++ b/pkg/cloudinfo/cistore.go
@@ -80,8 +80,8 @@ type CloudInfoStore interface {
 	Import(r io.Reader) error
 }
 
-// CacheProductStore in memory cloud product information storer
-type CacheProductStore struct {
+// cacheProductStore in memory cloud product information storer
+type cacheProductStore struct {
 	*cache.Cache
 	// all items are cached with this expiry
 	itemExpiry time.Duration
@@ -89,7 +89,7 @@ type CacheProductStore struct {
 }
 
 // Export writes the content of the store into the passed in writer
-func (cis *CacheProductStore) Export(w io.Writer) error {
+func (cis *cacheProductStore) Export(w io.Writer) error {
 	if err := cis.Save(w); err != nil {
 		cis.log.Error("failed to export the store", map[string]interface{}{"op": "export", "destination": "todo"})
 		return emperror.WrapWith(err, "failed to export the store", "op", "export", "destination", "todo")
@@ -98,7 +98,7 @@ func (cis *CacheProductStore) Export(w io.Writer) error {
 }
 
 // Import loads the store data from the standard input
-func (cis *CacheProductStore) Import(r io.Reader) error {
+func (cis *cacheProductStore) Import(r io.Reader) error {
 	if err := cis.Load(r); err != nil {
 		cis.log.Error("failed to load store data", map[string]interface{}{"op": "import", "destination": "todo"})
 		return emperror.WrapWith(err, "failed to load the store data", "op", "import", "destination", "todo")
@@ -106,80 +106,80 @@ func (cis *CacheProductStore) Import(r io.Reader) error {
 	return nil
 }
 
-func (cis *CacheProductStore) StoreRegion(provider, service string, val interface{}) {
+func (cis *cacheProductStore) StoreRegion(provider, service string, val interface{}) {
 	cis.Set(cis.getKey(RegionKeyTemplate, provider, service), val, cis.itemExpiry)
 }
 
-func (cis *CacheProductStore) GetRegion(provider, service string) (interface{}, bool) {
+func (cis *cacheProductStore) GetRegion(provider, service string) (interface{}, bool) {
 	return cis.Get(cis.getKey(RegionKeyTemplate, provider, service))
 }
 
-func (cis *CacheProductStore) StoreZone(provider, region string, val interface{}) {
+func (cis *cacheProductStore) StoreZone(provider, region string, val interface{}) {
 	cis.Set(cis.getKey(ZoneKeyTemplate, provider, region), val, cis.itemExpiry)
 }
 
-func (cis *CacheProductStore) GetZone(provider, region string) (interface{}, bool) {
+func (cis *cacheProductStore) GetZone(provider, region string) (interface{}, bool) {
 	return cis.Get(cis.getKey(ZoneKeyTemplate, provider, region))
 }
 
-func (cis *CacheProductStore) StorePrice(provider, region, instanceType string, val interface{}) {
+func (cis *cacheProductStore) StorePrice(provider, region, instanceType string, val interface{}) {
 	cis.Set(cis.getKey(PriceKeyTemplate, provider, region, instanceType), val, cis.itemExpiry)
 }
 
-func (cis *CacheProductStore) GetPrice(provider, region, instanceType string) (interface{}, bool) {
+func (cis *cacheProductStore) GetPrice(provider, region, instanceType string) (interface{}, bool) {
 	return cis.Get(cis.getKey(PriceKeyTemplate, provider, region, instanceType))
 }
 
-func (cis *CacheProductStore) StoreAttribute(provider, service, attribute string, val interface{}) {
+func (cis *cacheProductStore) StoreAttribute(provider, service, attribute string, val interface{}) {
 	cis.Set(cis.getKey(AttrKeyTemplate, provider, service, attribute), val, cis.itemExpiry)
 }
 
-func (cis *CacheProductStore) GetAttribute(provider, service, attribute string) (interface{}, bool) {
+func (cis *cacheProductStore) GetAttribute(provider, service, attribute string) (interface{}, bool) {
 	return cis.Get(cis.getKey(AttrKeyTemplate, provider, service, attribute))
 }
 
-func (cis *CacheProductStore) StoreVm(provider, service, region string, val interface{}) {
+func (cis *cacheProductStore) StoreVm(provider, service, region string, val interface{}) {
 	cis.Set(cis.getKey(VmKeyTemplate, provider, service, region), val, cis.itemExpiry)
 }
 
-func (cis *CacheProductStore) GetVm(provider, service, region string) (interface{}, bool) {
+func (cis *cacheProductStore) GetVm(provider, service, region string) (interface{}, bool) {
 	return cis.Get(cis.getKey(VmKeyTemplate, provider, service, region))
 }
 
-func (cis *CacheProductStore) StoreImage(provider, service, regionId string, val interface{}) {
+func (cis *cacheProductStore) StoreImage(provider, service, regionId string, val interface{}) {
 	cis.Set(cis.getKey(ImageKeyTemplate, provider, service, regionId), val, cis.itemExpiry)
 }
 
-func (cis *CacheProductStore) GetImage(provider, service, regionId string) (interface{}, bool) {
+func (cis *cacheProductStore) GetImage(provider, service, regionId string) (interface{}, bool) {
 	return cis.Get(cis.getKey(ImageKeyTemplate, provider, service, regionId))
 }
 
-func (cis *CacheProductStore) StoreVersion(provider, service, region string, val interface{}) {
+func (cis *cacheProductStore) StoreVersion(provider, service, region string, val interface{}) {
 	cis.Set(cis.getKey(VersionKeyTemplate, provider, service, region), val, cis.itemExpiry)
 }
 
-func (cis *CacheProductStore) GetVersion(provider, service, region string) (interface{}, bool) {
+func (cis *cacheProductStore) GetVersion(provider, service, region string) (interface{}, bool) {
 	return cis.Get(cis.getKey(VersionKeyTemplate, provider, service, region))
 }
 
-func (cis *CacheProductStore) StoreStatus(provider string, val interface{}) {
+func (cis *cacheProductStore) StoreStatus(provider string, val interface{}) {
 	cis.Set(cis.getKey(StatusKeyTemplate, provider), val, cis.itemExpiry)
 }
 
-func (cis *CacheProductStore) GetStatus(provider string) (interface{}, bool) {
+func (cis *cacheProductStore) GetStatus(provider string) (interface{}, bool) {
 	return cis.Get(cis.getKey(StatusKeyTemplate, provider))
 }
 
 // NewCacheProductStore creates a new store instance.
 // the backing cache is initialized with the defaultExpiration and cleanupInterval
 func NewCacheProductStore(cloudInfoExpiration, cleanupInterval time.Duration, logger logur.Logger) CloudInfoStore {
-	return &CacheProductStore{
+	return &cacheProductStore{
 		cache.New(cloudInfoExpiration, cleanupInterval),
 		cleanupInterval,
 		logger,
 	}
 }
 
-func (cis *CacheProductStore) getKey(keyTemplate string, args ...string) string {
+func (cis *cacheProductStore) getKey(keyTemplate string, args ...string) string {
 	return fmt.Sprintf(keyTemplate, args)
 }

--- a/pkg/cloudinfo/cloudinfo.go
+++ b/pkg/cloudinfo/cloudinfo.go
@@ -672,11 +672,9 @@ func (cpi *cachingCloudInfo) renewVersions(ctx context.Context, provider, servic
 		values []string
 		err    error
 	)
-
 	if values, err = cpi.cloudInfoers[provider].GetVersions(ctx, service, region); err != nil {
 		return nil, emperror.With(errors.New("failed to renew versions"), "provider", provider, "service", service, "region", region)
 	}
-
 	cpi.cloudInfoStore.StoreVersion(provider, service, region, values)
 	return values, nil
 

--- a/pkg/cloudinfo/cloudinfo.go
+++ b/pkg/cloudinfo/cloudinfo.go
@@ -378,6 +378,10 @@ func (cpi *cachingCloudInfo) renewShortLivedInfo(ctx context.Context, provider s
 		prices map[string]Price
 	)
 
+	if !cpi.cloudInfoers[provider].HasShortLivedPriceInfo() {
+		return nil, nil
+	}
+
 	if prices, err = cpi.cloudInfoers[provider].GetCurrentPrices(ctx, region); err != nil {
 		return nil, emperror.With(err, "failed to retrieve prices",
 			"provider", provider, "region", region)

--- a/pkg/cloudinfo/cloudinfo_test.go
+++ b/pkg/cloudinfo/cloudinfo_test.go
@@ -158,14 +158,14 @@ func TestNewCachingCloudInfo(t *testing.T) {
 	tests := []struct {
 		Name        string
 		CloudInfoer map[string]CloudInfoer
-		checker     func(info *CachingCloudInfo, err error)
+		checker     func(info *cachingCloudInfo, err error)
 	}{
 		{
 			Name: "product info successfully created",
 			CloudInfoer: map[string]CloudInfoer{
 				"dummy": &DummyCloudInfoer{},
 			},
-			checker: func(info *CachingCloudInfo, err error) {
+			checker: func(info *cachingCloudInfo, err error) {
 				assert.Nil(t, err, "should not get error")
 				assert.NotNil(t, info, "the product info should not be nil")
 			},
@@ -173,7 +173,7 @@ func TestNewCachingCloudInfo(t *testing.T) {
 		{
 			Name:        "validation should fail nil values",
 			CloudInfoer: nil,
-			checker: func(info *CachingCloudInfo, err error) {
+			checker: func(info *cachingCloudInfo, err error) {
 				assert.Nil(t, info, "the cloudinfo should be nil in case of error")
 				assert.EqualError(t, err, "could not create product infoer")
 			},

--- a/pkg/cloudinfo/cloudinfo_test.go
+++ b/pkg/cloudinfo/cloudinfo_test.go
@@ -182,7 +182,7 @@ func TestNewCachingCloudInfo(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			test.checker(NewCachingCloudInfo(10*time.Second, NewCacheProductStore(10*time.Minute, 5*time.Minute, logur.NewTestLogger()), test.CloudInfoer, metrics.NewNoOpMetricsReporter(), tracing.NewNoOpTracer()))
+			test.checker(NewCachingCloudInfo(NewCacheProductStore(10*time.Minute, 5*time.Minute, logur.NewTestLogger()), test.CloudInfoer, metrics.NewNoOpMetricsReporter(), tracing.NewNoOpTracer()))
 		})
 	}
 
@@ -247,7 +247,7 @@ func TestCachingCloudInfo_GetAttrValues(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			logger.Init(logur.NewTestLogger())
-			cloudInfo, _ := NewCachingCloudInfo(10*time.Second, NewCacheProductStore(5*time.Minute, 10*time.Minute, logur.NewTestLogger()), test.CloudInfoer, metrics.NewNoOpMetricsReporter(), tracing.NewNoOpTracer())
+			cloudInfo, _ := NewCachingCloudInfo(NewCacheProductStore(5*time.Minute, 10*time.Minute, logur.NewTestLogger()), test.CloudInfoer, metrics.NewNoOpMetricsReporter(), tracing.NewNoOpTracer())
 			test.checker(cloudInfo.GetAttrValues(context.Background(), "dummy", "dummyService", test.Attribute))
 		})
 	}
@@ -282,7 +282,7 @@ func TestCachingCloudInfo_Initialize(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cloudInfo, _ := NewCachingCloudInfo(10*time.Second, NewCacheProductStore(5*time.Minute, 10*time.Minute, logur.NewTestLogger()), test.CloudInfoer, metrics.NewNoOpMetricsReporter(), tracing.NewNoOpTracer())
+			cloudInfo, _ := NewCachingCloudInfo(NewCacheProductStore(5*time.Minute, 10*time.Minute, logur.NewTestLogger()), test.CloudInfoer, metrics.NewNoOpMetricsReporter(), tracing.NewNoOpTracer())
 			test.checker(cloudInfo.Initialize(context.Background(), "dummy"))
 		})
 	}
@@ -317,7 +317,7 @@ func TestCachingCloudInfo_renewShortLivedInfo(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			info, _ := NewCachingCloudInfo(10*time.Second, NewCacheProductStore(5*time.Minute, 10*time.Minute, logur.NewTestLogger()), test.CloudInfoer, metrics.NewNoOpMetricsReporter(), tracing.NewNoOpTracer())
+			info, _ := NewCachingCloudInfo(NewCacheProductStore(5*time.Minute, 10*time.Minute, logur.NewTestLogger()), test.CloudInfoer, metrics.NewNoOpMetricsReporter(), tracing.NewNoOpTracer())
 			test.checker(info.renewShortLivedInfo(context.Background(), "dummy", "dummyRegion"))
 		})
 	}
@@ -381,7 +381,7 @@ func TestCachingCloudInfo_GetPrice(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			info, _ := NewCachingCloudInfo(10*time.Second, NewCacheProductStore(5*time.Minute, 10*time.Minute, logur.NewTestLogger()), test.CloudInfoer, metrics.NewNoOpMetricsReporter(), tracing.NewNoOpTracer())
+			info, _ := NewCachingCloudInfo(NewCacheProductStore(5*time.Minute, 10*time.Minute, logur.NewTestLogger()), test.CloudInfoer, metrics.NewNoOpMetricsReporter(), tracing.NewNoOpTracer())
 			values, value, err := info.GetPrice(context.Background(), "dummy", "dummyRegion", "c3.large", test.zones)
 			test.checker(values, value, err)
 		})
@@ -418,7 +418,7 @@ func TestCachingCloudInfo_GetRegions(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			info, _ := NewCachingCloudInfo(10*time.Second, NewCacheProductStore(5*time.Minute, 10*time.Minute, logur.NewTestLogger()), test.CloudInfoer, metrics.NewNoOpMetricsReporter(), tracing.NewNoOpTracer())
+			info, _ := NewCachingCloudInfo(NewCacheProductStore(5*time.Minute, 10*time.Minute, logur.NewTestLogger()), test.CloudInfoer, metrics.NewNoOpMetricsReporter(), tracing.NewNoOpTracer())
 			test.checker(info.GetRegions(context.Background(), "dummy", "compute"))
 		})
 	}

--- a/pkg/cloudinfo/cloudinfo_test.go
+++ b/pkg/cloudinfo/cloudinfo_test.go
@@ -17,6 +17,7 @@ package cloudinfo
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -311,7 +312,7 @@ func TestCachingCloudInfo_renewShortLivedInfo(t *testing.T) {
 			},
 			checker: func(price map[string]Price, err error) {
 				assert.Nil(t, price, "the price should be nil")
-				assert.EqualError(t, err, GetCurrentPricesError)
+				assert.True(t, strings.Contains(err.Error(), GetCurrentPricesError))
 			},
 		},
 	}
@@ -375,7 +376,7 @@ func TestCachingCloudInfo_GetPrice(t *testing.T) {
 			checker: func(i float64, f float64, err error) {
 				assert.Equal(t, float64(0), i)
 				assert.Equal(t, float64(0), f)
-				assert.EqualError(t, err, GetCurrentPricesError)
+				assert.True(t, strings.Contains(err.Error(), GetCurrentPricesError))
 			},
 		},
 	}

--- a/pkg/cloudinfo/google/cloudinfo.go
+++ b/pkg/cloudinfo/google/cloudinfo.go
@@ -17,7 +17,6 @@ package google
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 	"net/http"
 	"os"
 	"strings"
@@ -25,6 +24,7 @@ import (
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo"
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo/metrics"
 	"github.com/banzaicloud/cloudinfo/pkg/logger"
+	"github.com/pkg/errors"
 	"golang.org/x/oauth2/google"
 	billing "google.golang.org/api/cloudbilling/v1"
 	"google.golang.org/api/compute/v1"
@@ -415,8 +415,8 @@ func (g *GceInfoer) GetCpuAttrName() string {
 }
 
 // GetServices returns the available services on the  provider
-func (g *GceInfoer) GetServices() ([]cloudinfo.ServiceDescriber, error) {
-	services := []cloudinfo.ServiceDescriber{
+func (g *GceInfoer) GetServices() ([]cloudinfo.Service, error) {
+	services := []cloudinfo.Service{
 		cloudinfo.NewService("compute"),
 		cloudinfo.NewService("gke")}
 	return services, nil

--- a/pkg/cloudinfo/infoer.go
+++ b/pkg/cloudinfo/infoer.go
@@ -48,7 +48,7 @@ type CloudInfoer interface {
 	GetCpuAttrName() string
 
 	// GetServices returns the available services on the given provider
-	GetServices() ([]ServiceDescriber, error)
+	GetServices() ([]Service, error)
 
 	// GetServices returns the available services on the  given region
 	GetService(ctx context.Context, service string) (ServiceDescriber, error)

--- a/pkg/cloudinfo/oracle/cloudinfo.go
+++ b/pkg/cloudinfo/oracle/cloudinfo.go
@@ -311,8 +311,8 @@ func (i *Infoer) HasShortLivedPriceInfo() bool {
 }
 
 // GetServices returns the available services on the  given region
-func (i *Infoer) GetServices() ([]cloudinfo.ServiceDescriber, error) {
-	services := []cloudinfo.ServiceDescriber{
+func (i *Infoer) GetServices() ([]cloudinfo.Service, error) {
+	services := []cloudinfo.Service{
 		cloudinfo.NewService("compute"),
 		cloudinfo.NewService("oke")}
 	return services, nil

--- a/pkg/cloudinfo/oracle/itra.go
+++ b/pkg/cloudinfo/oracle/itra.go
@@ -57,7 +57,7 @@ func (i *Infoer) GetCloudInfoFromITRA(ctx context.Context, partNumber string) (i
 		return i.cloudInfoCache[partNumber], nil
 	}
 
-	logger.Extract(ctx).Debug("getting product info for PN[%s]", map[string]interface{}{"PN": partNumber})
+	logger.Extract(ctx).Debug("getting product info]", map[string]interface{}{"PN": partNumber})
 
 	url := fmt.Sprintf("https://itra.oraclecloud.com/itas/.anon/myservices/api/v1/products?partNumber=%s", partNumber)
 	resp, err := http.Get(url)

--- a/pkg/cloudinfo/scrape.go
+++ b/pkg/cloudinfo/scrape.go
@@ -279,11 +279,12 @@ func (sm *scrapingManager) scrape(ctx context.Context) error {
 }
 
 func NewScrapingManager(provider string, infoer CloudInfoer, store CloudInfoStore, log logur.Logger, metrics metrics.Reporter, tracer tracing.Tracer) *scrapingManager {
+
 	return &scrapingManager{
 		provider: provider,
 		infoer:   infoer,
 		store:    store,
-		log:      log,
+		log:      logur.WithFields(log, map[string]interface{}{"provider": provider}),
 		metrics:  metrics,
 		tracer:   tracer,
 	}

--- a/pkg/cloudinfo/scrape.go
+++ b/pkg/cloudinfo/scrape.go
@@ -268,6 +268,7 @@ func (sm *scrapingManager) scrapePricesInAllRegions(ctx context.Context) error {
 func (sm *scrapingManager) scrape(ctx context.Context) error {
 	ctx, _ = sm.tracer.StartWithTags(ctx, fmt.Sprintf("scraping-%s", sm.provider), map[string]interface{}{"provider": sm.provider})
 	defer sm.tracer.EndSpan(ctx)
+	start := time.Now()
 
 	if err := sm.initialize(ctx); err != nil {
 		return err
@@ -275,6 +276,8 @@ func (sm *scrapingManager) scrape(ctx context.Context) error {
 	if err := sm.scrapeServiceInformation(ctx); err != nil {
 		return err
 	}
+
+	sm.metrics.ReportScrapeProviderCompleted(sm.provider, start)
 	return nil
 }
 

--- a/pkg/cloudinfo/scrape.go
+++ b/pkg/cloudinfo/scrape.go
@@ -1,0 +1,329 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudinfo
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/banzaicloud/cloudinfo/internal/app/cloudinfo/tracing"
+	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo/metrics"
+	"github.com/banzaicloud/cloudinfo/pkg/logger"
+	"github.com/goph/emperror"
+	"github.com/goph/logur"
+)
+
+// scrapingManager manages data renewal for a given provider
+// retrieves data from the cloud provider and stores it in the store
+type scrapingManager struct {
+	provider string
+	infoer   CloudInfoer
+	store    CloudInfoStore
+	metrics  metrics.Reporter
+	tracer   tracing.Tracer
+	log      logur.Logger
+}
+
+func (sm *scrapingManager) initialize(ctx context.Context) error {
+	var (
+		err    error
+		prices map[string]map[string]Price
+	)
+	ctx, _ = sm.tracer.StartWithTags(ctx, "initialize", map[string]interface{}{"provider": sm.provider})
+	defer sm.tracer.EndSpan(ctx)
+
+	sm.log.Info("initializing cloud product information")
+	if prices, err = sm.infoer.Initialize(ctx); err != nil {
+		sm.log.Warn("failed to initialize cloud product information")
+		return err
+	}
+	for region, ap := range prices {
+		for instType, p := range ap {
+			sm.store.StorePrice(sm.provider, region, instType, p)
+			metrics.OnDemandPriceGauge.WithLabelValues(sm.provider, region, instType).Set(p.OnDemandPrice)
+		}
+	}
+	sm.log.Info("finished initializing cloud product information")
+	return nil
+}
+
+func (sm *scrapingManager) scrapeServiceAttributes(ctx context.Context, services []Service) error {
+	var (
+		err      error
+		attrVals AttrValues
+	)
+	ctx, _ = sm.tracer.StartWithTags(ctx, "renew-attribute-values", map[string]interface{}{"provider": sm.provider})
+	defer sm.tracer.EndSpan(ctx)
+
+	sm.log.Info("start to renew attribute values")
+	for _, service := range services {
+		for _, attr := range []string{sm.infoer.GetCpuAttrName(), sm.infoer.GetMemoryAttrName()} {
+
+			if attrVals, err = sm.infoer.GetAttributeValues(ctx, service.ServiceName(), attr); err != nil {
+				sm.metrics.ReportScrapeFailure(sm.provider, "N/A", "N/A")
+				sm.log.Error("failed to retrieve attribute values")
+				// should the process go forward here?
+				return emperror.WrapWith(err, "failed to retrieve attribute values", "attribute", attr)
+			}
+			sm.store.StoreAttribute(sm.provider, service.ServiceName(), attr, attrVals)
+		}
+	}
+	return nil
+}
+
+func (sm *scrapingManager) scrapeServiceRegionProducts(ctx context.Context, service Service, regionId string) error {
+	var (
+		values []VmInfo
+		err    error
+	)
+	sm.log.Debug("retrieving regional product information", map[string]interface{}{"region": regionId})
+	if values, err = sm.infoer.GetProducts(ctx, service.ServiceName(), regionId); err != nil {
+
+		sm.log.Error("failed to retrieve products for region", map[string]interface{}{"service": service.ServiceName(), "region": regionId})
+		return emperror.WrapWith(err, "failed to retrieve products for region",
+			"provider", sm.provider, "service", service.ServiceName(), "region", regionId)
+	}
+
+	for _, vm := range values {
+		if vm.OnDemandPrice > 0 {
+			metrics.OnDemandPriceGauge.WithLabelValues(sm.provider, regionId, vm.Type).Set(vm.OnDemandPrice)
+		}
+	}
+	sm.store.StoreVm(sm.provider, service.ServiceName(), regionId, values)
+
+	return nil
+}
+
+func (sm *scrapingManager) scrapeServiceRegionImages(ctx context.Context, service Service, regionId string) error {
+	var (
+		images []Image
+		err    error
+	)
+	if sm.infoer.HasImages() {
+		sm.log.Debug("retrieving regional image information", map[string]interface{}{"region": regionId})
+		if images, err = sm.infoer.GetServiceImages(service.ServiceName(), regionId); err != nil {
+
+			sm.log.Warn("failed to retrieve service images for region",
+				map[string]interface{}{"service": service.ServiceName(), "region": regionId})
+			return emperror.WrapWith(err, "failed to retrieve service images for region",
+				"provider", sm.provider, "service", service.ServiceName(), "region", regionId)
+		}
+		sm.store.StoreImage(sm.provider, service.ServiceName(), regionId, images)
+	}
+	return nil
+}
+
+func (sm *scrapingManager) scrapeServiceRegionVersions(ctx context.Context, service Service, regionId string) error {
+	var (
+		versions []string
+		err      error
+	)
+
+	sm.log.Debug("retrieving regional version information", map[string]interface{}{"region": regionId})
+	if versions, err = sm.infoer.GetVersions(ctx, service.ServiceName(), regionId); err != nil {
+		sm.log.Warn("failed to retrieve service versions for region")
+	}
+	sm.store.StoreVersion(sm.provider, service.ServiceName(), regionId, versions)
+
+	return nil
+}
+
+func (sm *scrapingManager) scrapeServiceRegionInfo(ctx context.Context, services []Service) error {
+	var (
+		regions map[string]string
+		err     error
+	)
+	ctx, _ = sm.tracer.StartWithTags(ctx, "scrape-region-info", map[string]interface{}{"provider": sm.provider})
+	defer sm.tracer.EndSpan(ctx)
+
+	sm.log.Info("start to scrape service region information")
+	for _, service := range services {
+		if regions, err = sm.infoer.GetRegions(ctx, service.ServiceName()); err != nil {
+
+			sm.metrics.ReportScrapeFailure(sm.provider, service.ServiceName(), "N/A")
+			sm.log.Error("failed to retrieve regions")
+			return emperror.WrapWith(err, "failed to retrieve regions",
+				"provider", sm.provider, "service", service.ServiceName())
+		}
+
+		for regionId := range regions {
+
+			if err = sm.scrapeServiceRegionProducts(ctx, service, regionId); err != nil {
+				sm.metrics.ReportScrapeFailure(sm.provider, service.ServiceName(), regionId)
+			}
+
+			if err = sm.scrapeServiceRegionImages(ctx, service, regionId); err != nil {
+				sm.metrics.ReportScrapeFailure(sm.provider, service.ServiceName(), regionId)
+			}
+
+			if err = sm.scrapeServiceRegionVersions(ctx, service, regionId); err != nil {
+				sm.metrics.ReportScrapeFailure(sm.provider, service.ServiceName(), regionId)
+			}
+		}
+	}
+	return nil
+}
+
+func (sm *scrapingManager) updateStatus(ctx context.Context) {
+	values := strconv.Itoa(int(time.Now().UnixNano() / 1e6))
+	sm.log.Info("updating status for provider")
+	sm.store.StoreStatus(sm.provider, values)
+}
+
+// scrapeServiceInformation scrapes service and region dependant cloud information and stores its
+func (sm *scrapingManager) scrapeServiceInformation(ctx context.Context) error {
+	var (
+		err      error
+		services []Service
+	)
+
+	if services, err = sm.infoer.GetServices(); err != nil {
+		sm.metrics.ReportScrapeFailure(sm.provider, "N/A", "N/A")
+		sm.log.Error("failed to renew products")
+		return emperror.Wrap(err, "failed to retrieve services")
+	}
+
+	if err := sm.scrapeServiceAttributes(ctx, services); err != nil {
+		sm.log.Error("failed to load service attribute values")
+		return emperror.Wrap(err, "failed to load service attribute values")
+	}
+
+	if err := sm.scrapeServiceRegionInfo(ctx, services); err != nil {
+		sm.log.Error("failed to load service region information")
+		return emperror.Wrap(err, "failed to load service region information")
+	}
+
+	sm.updateStatus(ctx)
+
+	return nil
+}
+
+func (sm *scrapingManager) scrapePricesInRegion(ctx context.Context, region string, wg *sync.WaitGroup) error {
+	var (
+		err    error
+		prices map[string]Price
+	)
+	if wg != nil {
+		defer wg.Done()
+	}
+	start := time.Now()
+	if prices, err = sm.infoer.GetCurrentPrices(ctx, region); err != nil {
+		sm.metrics.ReportScrapeShortLivedFailure(sm.provider, region)
+		sm.log.Error("failed to scrape prices in region")
+		return emperror.With(err, "failed to crape prices in region", "provider", sm.provider, "region", region)
+	}
+
+	for instType, price := range prices {
+		sm.store.StorePrice(sm.provider, region, instType, price)
+	}
+
+	sm.metrics.ReportScrapeRegionShortLivedCompleted(sm.provider, region, start)
+	return nil
+}
+
+func (sm *scrapingManager) scrapePricesInAllRegions(ctx context.Context) error {
+	var (
+		regions map[string]string
+		err     error
+		wg      sync.WaitGroup
+	)
+	// record current time for metrics
+	start := time.Now()
+	if regions, err = sm.infoer.GetRegions(ctx, "compute"); err != nil {
+		sm.log.Error("failed to retrieve regions")
+		return emperror.WrapWith(err, "failed to retrieve regions", "provider", sm.provider, "service", "compute")
+	}
+
+	for regionId := range regions {
+		wg.Add(1)
+		go sm.scrapePricesInRegion(ctx, regionId, &wg)
+	}
+	wg.Wait()
+	sm.metrics.ReportScrapeProviderShortLivedCompleted(sm.provider, start)
+	return nil
+}
+
+// scrape implements the scraping logic for a provider
+func (sm *scrapingManager) scrape(ctx context.Context) error {
+	if err := sm.initialize(ctx); err != nil {
+		return err
+	}
+	if err := sm.scrapeServiceInformation(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func NewScrapingManager(provider string, infoer CloudInfoer, store CloudInfoStore, log logur.Logger, metrics metrics.Reporter, tracer tracing.Tracer) *scrapingManager {
+	return &scrapingManager{
+		provider: provider,
+		infoer:   infoer,
+		store:    store,
+		log:      log,
+		metrics:  metrics,
+		tracer:   tracer,
+	}
+}
+
+type ScrapingDriver struct {
+	scrapingManagers []*scrapingManager
+	renewalInterval  time.Duration
+	log              logur.Logger
+}
+
+func (sd *ScrapingDriver) StartScraping(ctx context.Context) error {
+
+	if err := NewPeriodicExecutor(sd.renewalInterval).Execute(ctx, sd.renewAll); err != nil {
+		sd.log.Error("failed to scrape for vm information")
+		return emperror.Wrap(err, "failed to scrape cloud information")
+	}
+
+	// start scraping providers for pricing information
+	if err := NewPeriodicExecutor(4*time.Minute).Execute(ctx, sd.renewShortLived); err != nil {
+		logger.Extract(ctx).Info("failed to scrape for pricing information")
+		return nil
+	}
+
+	return nil
+}
+
+func (sd *ScrapingDriver) renewAll(ctx context.Context) {
+	for _, manager := range sd.scrapingManagers {
+		go manager.scrape(ctx)
+	}
+}
+
+func (sd *ScrapingDriver) renewShortLived(ctx context.Context) {
+	for _, manager := range sd.scrapingManagers {
+		go manager.scrapePricesInAllRegions(ctx)
+	}
+}
+
+func NewScrapingDriver(renewalInterval time.Duration, infoers map[string]CloudInfoer,
+	store CloudInfoStore, log logur.Logger, metrics metrics.Reporter, tracer tracing.Tracer) *ScrapingDriver {
+	var managers []*scrapingManager
+
+	for provider, infoer := range infoers {
+		managers = append(managers, NewScrapingManager(provider, infoer, store, log, metrics, tracer))
+	}
+
+	return &ScrapingDriver{
+		managers,
+		renewalInterval,
+		log,
+	}
+}

--- a/pkg/cloudinfo/scrape.go
+++ b/pkg/cloudinfo/scrape.go
@@ -319,7 +319,13 @@ func (sd *ScrapingDriver) renewAll(ctx context.Context) {
 }
 
 func (sd *ScrapingDriver) renewShortLived(ctx context.Context) {
+
 	for _, manager := range sd.scrapingManagers {
+		if !manager.infoer.HasShortLivedPriceInfo() {
+			// the manager's logger is used here - that has the provider in it's context
+			manager.log.Debug("skip scraping for short lived prices (not applicable for provider)")
+			return
+		}
 		go manager.scrapePricesInAllRegions(ctx)
 	}
 }

--- a/pkg/cloudinfo/scrape.go
+++ b/pkg/cloudinfo/scrape.go
@@ -16,6 +16,7 @@ package cloudinfo
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"sync"
 	"time"
@@ -190,6 +191,8 @@ func (sm *scrapingManager) scrapeServiceInformation(ctx context.Context) error {
 		err      error
 		services []Service
 	)
+	ctx, _ = sm.tracer.StartWithTags(ctx, "scrape-service-info", map[string]interface{}{"provider": sm.provider})
+	defer sm.tracer.EndSpan(ctx)
 
 	if services, err = sm.infoer.GetServices(); err != nil {
 		sm.metrics.ReportScrapeFailure(sm.provider, "N/A", "N/A")
@@ -241,6 +244,10 @@ func (sm *scrapingManager) scrapePricesInAllRegions(ctx context.Context) error {
 		err     error
 		wg      sync.WaitGroup
 	)
+
+	ctx, _ = sm.tracer.StartWithTags(ctx, "scrape-region-prices", map[string]interface{}{"provider": sm.provider})
+	defer sm.tracer.EndSpan(ctx)
+
 	// record current time for metrics
 	start := time.Now()
 	if regions, err = sm.infoer.GetRegions(ctx, "compute"); err != nil {
@@ -259,6 +266,9 @@ func (sm *scrapingManager) scrapePricesInAllRegions(ctx context.Context) error {
 
 // scrape implements the scraping logic for a provider
 func (sm *scrapingManager) scrape(ctx context.Context) error {
+	ctx, _ = sm.tracer.StartWithTags(ctx, fmt.Sprintf("scraping-%s", sm.provider), map[string]interface{}{"provider": sm.provider})
+	defer sm.tracer.EndSpan(ctx)
+
 	if err := sm.initialize(ctx); err != nil {
 		return err
 	}

--- a/pkg/cloudinfo/scrape.go
+++ b/pkg/cloudinfo/scrape.go
@@ -163,17 +163,17 @@ func (sm *scrapingManager) scrapeServiceRegionInfo(ctx context.Context, services
 
 		for regionId := range regions {
 
+			start := time.Now()
 			if err = sm.scrapeServiceRegionProducts(ctx, service, regionId); err != nil {
 				sm.metrics.ReportScrapeFailure(sm.provider, service.ServiceName(), regionId)
 			}
-
 			if err = sm.scrapeServiceRegionImages(ctx, service, regionId); err != nil {
 				sm.metrics.ReportScrapeFailure(sm.provider, service.ServiceName(), regionId)
 			}
-
 			if err = sm.scrapeServiceRegionVersions(ctx, service, regionId); err != nil {
 				sm.metrics.ReportScrapeFailure(sm.provider, service.ServiceName(), regionId)
 			}
+			sm.metrics.ReportScrapeRegionCompleted(sm.provider, service.ServiceName(), regionId, start)
 		}
 	}
 	return nil
@@ -247,6 +247,7 @@ func (sm *scrapingManager) scrapePricesInAllRegions(ctx context.Context) error {
 
 	ctx, _ = sm.tracer.StartWithTags(ctx, "scrape-region-prices", map[string]interface{}{"provider": sm.provider})
 	defer sm.tracer.EndSpan(ctx)
+	sm.log.Info("start scraping prices")
 
 	// record current time for metrics
 	start := time.Now()
@@ -268,6 +269,8 @@ func (sm *scrapingManager) scrapePricesInAllRegions(ctx context.Context) error {
 func (sm *scrapingManager) scrape(ctx context.Context) error {
 	ctx, _ = sm.tracer.StartWithTags(ctx, fmt.Sprintf("scraping-%s", sm.provider), map[string]interface{}{"provider": sm.provider})
 	defer sm.tracer.EndSpan(ctx)
+
+	sm.log.Info("start scraping for provider information")
 	start := time.Now()
 
 	if err := sm.initialize(ctx); err != nil {

--- a/pkg/cloudinfo/scrape.go
+++ b/pkg/cloudinfo/scrape.go
@@ -324,7 +324,7 @@ func (sd *ScrapingDriver) renewShortLived(ctx context.Context) {
 		if !manager.infoer.HasShortLivedPriceInfo() {
 			// the manager's logger is used here - that has the provider in it's context
 			manager.log.Debug("skip scraping for short lived prices (not applicable for provider)")
-			return
+			continue
 		}
 		go manager.scrapePricesInAllRegions(ctx)
 	}

--- a/pkg/cloudinfo/types.go
+++ b/pkg/cloudinfo/types.go
@@ -34,9 +34,6 @@ type CloudInfo interface {
 	// GetProvider retrieves information about the provider
 	GetProvider(ctx context.Context, provider string) (Provider, error)
 
-	// Start starts the product information retrieval in a new goroutine
-	Start(ctx context.Context)
-
 	// Initialize is called once per product info renewals so it can be used to download a large price descriptor
 	Initialize(ctx context.Context, provider string) (map[string]map[string]Price, error)
 

--- a/pkg/cloudinfo/types.go
+++ b/pkg/cloudinfo/types.go
@@ -62,6 +62,14 @@ type CloudInfo interface {
 	GetInfoer(ctx context.Context, provider string) (CloudInfoer, error)
 
 	RefreshProvider(ctx context.Context, provider string) error
+
+	GetStatus(provider string) (string, error)
+
+	GetProductDetails(ctx context.Context, provider, service, region string) ([]ProductDetails, error)
+
+	GetServiceImages(ctx context.Context, provider, service, region string) ([]ImageDescriber, error)
+
+	GetVersions(ctx context.Context, provider, service, region string) ([]string, error)
 }
 
 // AttrValue represents an attribute value


### PR DESCRIPTION
* generic cloud info scraping logic has been factored out to specialized components:
** scrapingManager - in charge for scraping one provider and storing the processed result in the store (for a single provider)
** scraping driver - in charge for scheduling the scraping process
With this the CachingCloud info implementation has been freed up of these tasks - it can "focus" on serving requests through handlers ...

* unexported unnecessarily exported structs
* removed outdated ctx logger from the renewal / scraping components
* partially removed deprecated code (from the cloudinfo implementation) -some leftovers still ther not to break actual functionality
* refined tracing (with the new structure it's possible to have more accurate spans!)
 
