### PR TITLE
 add category to virtual machines

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -27,9 +27,10 @@
   source = "github.com/apache/thrift"
 
 [[projects]]
-  digest = "1:aa9951e969a5db808d125fca856fe00660d471a8ba9d9063d4600437f7f85dda"
+  digest = "1:0361aac45bd3acbaf3b3b81b30be3587ace855686cbe4695e6e7aa3fba0d06d8"
   name = "github.com/Azure/azure-sdk-for-go"
   packages = [
+    "services/compute/mgmt/2017-09-01/skus",
     "services/compute/mgmt/2018-04-01/compute",
     "services/containerservice/mgmt/2018-03-31/containerservice",
     "services/preview/commerce/mgmt/2015-06-01-preview/commerce",
@@ -903,6 +904,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2017-09-01/skus",
     "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute",
     "github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2018-03-31/containerservice",
     "github.com/Azure/azure-sdk-for-go/services/preview/commerce/mgmt/2015-06-01-preview/commerce",

--- a/api/openapi-spec/cloudinfo.json
+++ b/api/openapi-spec/cloudinfo.json
@@ -620,6 +620,10 @@
           "type": "boolean",
           "x-go-name": "Burst"
         },
+        "category": {
+          "type": "string",
+          "x-go-name": "Category"
+        },
         "cpusPerVm": {
           "type": "number",
           "format": "double",

--- a/api/openapi-spec/cloudinfo.yaml
+++ b/api/openapi-spec/cloudinfo.yaml
@@ -460,6 +460,9 @@ components:
           description: Burst this is derived for now
           type: boolean
           x-go-name: Burst
+        category:
+          type: string
+          x-go-name: Category
         cpusPerVm:
           type: number
           format: double

--- a/pkg/cloudinfo-client/models/product_details.go
+++ b/pkg/cloudinfo-client/models/product_details.go
@@ -24,6 +24,9 @@ type ProductDetails struct {
 	// Burst this is derived for now
 	Burst bool `json:"burst,omitempty"`
 
+	// category
+	Category string `json:"category,omitempty"`
+
 	// cpus
 	Cpus float64 `json:"cpusPerVm,omitempty"`
 

--- a/pkg/cloudinfo/alibaba/category_mapper.go
+++ b/pkg/cloudinfo/alibaba/category_mapper.go
@@ -40,7 +40,7 @@ func newAlibabaCategoryMapper() *AlibabaCategoryMapper {
 	return &AlibabaCategoryMapper{}
 }
 
-// MapCategory maps the family of the alibaba instance to the category supported by telescopes
+// MapCategory maps the family of the alibaba instance to category
 func (nm *AlibabaCategoryMapper) MapCategory(name string) (string, error) {
 	family := strings.Split(name, ".")[1]
 	if strings.Contains(family, "-") {

--- a/pkg/cloudinfo/alibaba/category_mapper.go
+++ b/pkg/cloudinfo/alibaba/category_mapper.go
@@ -1,0 +1,56 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alibaba
+
+import (
+	"strings"
+
+	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo"
+	"github.com/pkg/errors"
+)
+
+var (
+	categoryMap = map[string][]string{
+		cloudinfo.CategoryGeneral: {"g5", "sn2ne", "hfg5", "ebmhfg5", "ebmg5", "sccg5", "t5", "xn4", "n4", "mn4", "sn2", "n1", "n2", "s2", "t1", "s1", "s3"},
+		cloudinfo.CategoryCompute: {"ic5", "c5", "sn1ne", "hfc5", "ebmc4", "scch5", "sn1", "c4", "ce4", "cm4", "c1", "c2"},
+		cloudinfo.CategoryMemory:  {"r5", "re4", "re4e", "se1ne", "se1", "e4", "e3", "m1", "m2"},
+		cloudinfo.CategoryStorage: {"d1ne", "d1", "i2", "i2g", "i1"},
+		cloudinfo.CategoryGpu:     {"gn6v", "gn5", "gn5i", "gn4", "ga1", "f1", "f3"},
+	}
+)
+
+// AlibabaCategoryMapper module object for sort virtual machines into categories
+type AlibabaCategoryMapper struct {
+}
+
+// newAlibabaNetworkMapper initializes the category mapper struct
+func newAlibabaCategoryMapper() *AlibabaCategoryMapper {
+	return &AlibabaCategoryMapper{}
+}
+
+// MapCategory maps the family of the alibaba instance to the category supported by telescopes
+func (nm *AlibabaCategoryMapper) MapCategory(name string) (string, error) {
+	family := strings.Split(name, ".")[1]
+	if strings.Contains(family, "-") {
+		family = strings.Split(family, "-")[0]
+	}
+
+	for category, strVals := range categoryMap {
+		if cloudinfo.Contains(strVals, family) {
+			return category, nil
+		}
+	}
+	return "", errors.Wrap(errors.New(family), "could not determine the category")
+}

--- a/pkg/cloudinfo/alibaba/category_mapper.go
+++ b/pkg/cloudinfo/alibaba/category_mapper.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo"
+	"github.com/goph/emperror"
 	"github.com/pkg/errors"
 )
 
@@ -31,17 +32,8 @@ var (
 	}
 )
 
-// AlibabaCategoryMapper module object for sort virtual machines into categories
-type AlibabaCategoryMapper struct {
-}
-
-// newAlibabaNetworkMapper initializes the category mapper struct
-func newAlibabaCategoryMapper() *AlibabaCategoryMapper {
-	return &AlibabaCategoryMapper{}
-}
-
-// MapCategory maps the family of the alibaba instance to category
-func (nm *AlibabaCategoryMapper) MapCategory(name string) (string, error) {
+// mapCategory maps the family of the alibaba instance to category
+func (a *AlibabaInfoer) mapCategory(name string) (string, error) {
 	family := strings.Split(name, ".")[1]
 	if strings.Contains(family, "-") {
 		family = strings.Split(family, "-")[0]
@@ -52,5 +44,5 @@ func (nm *AlibabaCategoryMapper) MapCategory(name string) (string, error) {
 			return category, nil
 		}
 	}
-	return "", errors.Wrap(errors.New(family), "could not determine the category")
+	return "", emperror.Wrap(errors.New(family), "could not determine the category")
 }

--- a/pkg/cloudinfo/alibaba/cloudinfo.go
+++ b/pkg/cloudinfo/alibaba/cloudinfo.go
@@ -73,8 +73,8 @@ func (a *AlibabaInfoer) Initialize() (map[string]map[string]cloudinfo.Price, err
 }
 
 func (a *AlibabaInfoer) getCurrentSpotPrices(region string) (map[string]cloudinfo.SpotPriceInfo, error) {
-	log := log.WithFields(a.log, map[string]interface{}{"region": region})
-	log.Debug("start retrieving spot price data")
+	logger := log.WithFields(a.log, map[string]interface{}{"region": region})
+	logger.Debug("start retrieving spot price data")
 	priceInfo := make(map[string]cloudinfo.SpotPriceInfo)
 
 	zones, err := a.getZones(region)
@@ -88,7 +88,7 @@ func (a *AlibabaInfoer) getCurrentSpotPrices(region string) (map[string]cloudinf
 
 				describeSpotPriceHistory, err := a.client.ProcessCommonRequest(a.describeSpotPriceHistoryRequest(region, instanceType))
 				if err != nil {
-					log.Error("failed to get spot price history", map[string]interface{}{"instancetype": instanceType})
+					logger.Error("failed to get spot price history", map[string]interface{}{"instancetype": instanceType})
 					continue
 				}
 
@@ -112,7 +112,7 @@ func (a *AlibabaInfoer) getCurrentSpotPrices(region string) (map[string]cloudinf
 			}
 		}
 	}
-	log.Debug("retrieved spot price data")
+	logger.Debug("retrieved spot price data")
 	return priceInfo, nil
 }
 
@@ -133,8 +133,8 @@ func (a *AlibabaInfoer) getZones(region string) ([]ecs.Zone, error) {
 }
 
 func (a *AlibabaInfoer) GetVirtualMachines(region string) ([]cloudinfo.VmInfo, error) {
-	log := log.WithFields(a.log, map[string]interface{}{"region": region})
-	log.Debug("getting product info")
+	logger := log.WithFields(a.log, map[string]interface{}{"region": region})
+	logger.Debug("getting product info")
 	vms := make([]cloudinfo.VmInfo, 0)
 
 	instanceTypes, err := a.getInstanceTypes()
@@ -165,11 +165,19 @@ func (a *AlibabaInfoer) GetVirtualMachines(region string) ([]cloudinfo.VmInfo, e
 			ntwPerf := fmt.Sprintf("%.1f Gbit/s", float64(instanceType.InstanceBandwidthRx)/1024000)
 			ntwPerfCat, err := ntwMapper.MapNetworkPerf(ntwPerf)
 			if err != nil {
-				log.Debug(emperror.Wrap(err, "failed to get network performance category").Error(),
+				logger.Debug(emperror.Wrap(err, "failed to get network performance category").Error(),
+					map[string]interface{}{"instanceType": instanceType.InstanceTypeId})
+			}
+
+			categoryMapper := newAlibabaCategoryMapper()
+			category, err := categoryMapper.MapCategory(instanceType.InstanceTypeId)
+			if err != nil {
+				logger.Debug(emperror.Wrap(err, "failed to get virtual machine category").Error(),
 					map[string]interface{}{"instanceType": instanceType.InstanceTypeId})
 			}
 
 			vms = append(vms, cloudinfo.VmInfo{
+				Category:   category,
 				Type:       instanceType.InstanceTypeId,
 				Cpus:       float64(instanceType.CpuCoreCount),
 				Mem:        instanceType.MemorySize,
@@ -187,7 +195,7 @@ func (a *AlibabaInfoer) GetVirtualMachines(region string) ([]cloudinfo.VmInfo, e
 		return nil, err
 	}
 
-	log.Debug("found vms", map[string]interface{}{"numberOfVms": len(virtualMachines)})
+	logger.Debug("found vms", map[string]interface{}{"numberOfVms": len(virtualMachines)})
 	return virtualMachines, nil
 }
 
@@ -306,6 +314,7 @@ func (a *AlibabaInfoer) getOnDemandPrice(vms []cloudinfo.VmInfo, region string) 
 
 	for _, vm := range vms {
 		vmsWithPrice = append(vmsWithPrice, cloudinfo.VmInfo{
+			Category:      vm.Category,
 			Type:          vm.Type,
 			OnDemandPrice: price[vm.Type],
 			Cpus:          vm.Cpus,
@@ -339,8 +348,8 @@ func (a *AlibabaInfoer) getPrice(instanceTypes []string, region string) (bssopen
 
 // GetZones returns the availability zones in a region
 func (a *AlibabaInfoer) GetZones(region string) ([]string, error) {
-	log := log.WithFields(a.log, map[string]interface{}{"region": region})
-	log.Debug("getting zones")
+	logger := log.WithFields(a.log, map[string]interface{}{"region": region})
+	logger.Debug("getting zones")
 
 	var zones []string
 
@@ -353,14 +362,14 @@ func (a *AlibabaInfoer) GetZones(region string) ([]string, error) {
 		zones = append(zones, zone.ZoneId)
 	}
 
-	log.Debug("found zones", map[string]interface{}{"numberOfZones": len(zones)})
+	logger.Debug("found zones", map[string]interface{}{"numberOfZones": len(zones)})
 	return zones, nil
 }
 
 // GetRegions returns a map with available regions
 func (a *AlibabaInfoer) GetRegions(service string) (map[string]string, error) {
-	log := log.WithFields(a.log, map[string]interface{}{"service": service})
-	log.Debug("getting regions")
+	logger := log.WithFields(a.log, map[string]interface{}{"service": service})
+	logger.Debug("getting regions")
 
 	describeRegions, err := a.client.ProcessCommonRequest(a.describeRegionsRequest())
 	if err != nil {
@@ -379,7 +388,7 @@ func (a *AlibabaInfoer) GetRegions(service string) (map[string]string, error) {
 		regionIdMap[region.RegionId] = region.LocalName
 	}
 
-	log.Debug("found regions", map[string]interface{}{"numberOfRegions": len(regionIdMap)})
+	logger.Debug("found regions", map[string]interface{}{"numberOfRegions": len(regionIdMap)})
 	return regionIdMap, nil
 }
 

--- a/pkg/cloudinfo/alibaba/cloudinfo.go
+++ b/pkg/cloudinfo/alibaba/cloudinfo.go
@@ -169,8 +169,7 @@ func (a *AlibabaInfoer) GetVirtualMachines(region string) ([]cloudinfo.VmInfo, e
 					map[string]interface{}{"instanceType": instanceType.InstanceTypeId})
 			}
 
-			categoryMapper := newAlibabaCategoryMapper()
-			category, err := categoryMapper.MapCategory(instanceType.InstanceTypeId)
+			category, err := a.mapCategory(instanceType.InstanceTypeId)
 			if err != nil {
 				logger.Debug(emperror.Wrap(err, "failed to get virtual machine category").Error(),
 					map[string]interface{}{"instanceType": instanceType.InstanceTypeId})

--- a/pkg/cloudinfo/alibaba/cloudinfo.go
+++ b/pkg/cloudinfo/alibaba/cloudinfo.go
@@ -185,7 +185,7 @@ func (a *AlibabaInfoer) GetVirtualMachines(region string) ([]cloudinfo.VmInfo, e
 				NtwPerf:    ntwPerf,
 				NtwPerfCat: ntwPerfCat,
 				Zones:      zones,
-				Attributes: cloudinfo.Attributes(fmt.Sprint(instanceType.CpuCoreCount), fmt.Sprint(instanceType.MemorySize), ntwPerfCat),
+				Attributes: cloudinfo.Attributes(fmt.Sprint(instanceType.CpuCoreCount), fmt.Sprint(instanceType.MemorySize), ntwPerfCat, category),
 			})
 		}
 	}

--- a/pkg/cloudinfo/alibaba/network_mapper.go
+++ b/pkg/cloudinfo/alibaba/network_mapper.go
@@ -21,10 +21,10 @@ import (
 
 var (
 	ntwPerfMap = map[string][]string{
-		cloudinfo.NetwLow:   {"0.1 Gbit/s", "0.2 Gbit/s", "0.4 Gbit/s", "0.5 Gbit/s", "0.8 Gbit/s", "1.0 Gbit/s", "1.2 Gbit/s", "1.5 Gbit/s", "2.0 Gbit/s"},
+		cloudinfo.NtwLow:    {"0.0 Gbit/s", "0.1 Gbit/s", "0.2 Gbit/s", "0.4 Gbit/s", "0.5 Gbit/s", "0.8 Gbit/s", "1.0 Gbit/s", "1.2 Gbit/s", "1.5 Gbit/s", "2.0 Gbit/s"},
 		cloudinfo.NtwMedium: {"2.5 Gbit/s", "3.0 Gbit/s", "4.0 Gbit/s", "4.5 Gbit/s", "5.0 Gbit/s", "6.0 Gbit/s", "7.5 Gbit/s", "8.0 Gbit/s"},
 		cloudinfo.NtwHight:  {"10.0 Gbit/s", "12.0 Gbit/s"},
-		cloudinfo.NtwExtra:  {"16.0 Gbit/s", "17.0 Gbit/s", "20.0 Gbit/s", "25.0 Gbit/s", "35.0 Gbit/s"},
+		cloudinfo.NtwExtra:  {"15.0 Gbit/s", "16.0 Gbit/s", "17.0 Gbit/s", "20.0 Gbit/s", "25.0 Gbit/s", "30.0 Gbit/s", "35.0 Gbit/s"},
 	}
 )
 

--- a/pkg/cloudinfo/amazon/cloudinfo.go
+++ b/pkg/cloudinfo/amazon/cloudinfo.go
@@ -138,6 +138,10 @@ func (e *Ec2Infoer) GetVirtualMachines(region string) ([]cloudinfo.VmInfo, error
 			logger.Warn("could not retrieve instance type", map[string]interface{}{"instancetype": instanceType})
 			continue
 		}
+		instanceFamily, err := pd.getDataForKey("instanceFamily")
+		if err != nil {
+			logger.Warn("could not retrieve instance family", map[string]interface{}{"instanceFamily": instanceFamily})
+		}
 		cpusStr, err := pd.getDataForKey("vcpu")
 		if err != nil {
 			missingAttributes[instanceType] = append(missingAttributes[instanceType], "cpu")
@@ -178,6 +182,7 @@ func (e *Ec2Infoer) GetVirtualMachines(region string) ([]cloudinfo.VmInfo, error
 		mem, _ := strconv.ParseFloat(strings.Split(memStr, " ")[0], 64)
 		gpus, _ := strconv.ParseFloat(gpu, 64)
 		vm := cloudinfo.VmInfo{
+			Category:      instanceFamily,
 			Type:          instanceType,
 			OnDemandPrice: onDemandPrice,
 			Cpus:          cpus,

--- a/pkg/cloudinfo/amazon/cloudinfo.go
+++ b/pkg/cloudinfo/amazon/cloudinfo.go
@@ -191,7 +191,7 @@ func (e *Ec2Infoer) GetVirtualMachines(region string) ([]cloudinfo.VmInfo, error
 			NtwPerf:       ntwPerf,
 			NtwPerfCat:    ntwPerfCat,
 			CurrentGen:    currGen,
-			Attributes:    cloudinfo.Attributes(cpusStr, strings.Split(memStr, " ")[0], ntwPerfCat),
+			Attributes:    cloudinfo.Attributes(cpusStr, strings.Split(memStr, " ")[0], ntwPerfCat, instanceFamily),
 		}
 		vms = append(vms, vm)
 	}

--- a/pkg/cloudinfo/amazon/network_mapper.go
+++ b/pkg/cloudinfo/amazon/network_mapper.go
@@ -36,7 +36,7 @@ var (
 		//"Up to 10 Gigabit"
 		//"Very Low"
 
-		cloudinfo.NetwLow:   {"Very Low", "Low", "Low to Moderate"},
+		cloudinfo.NtwLow:    {"Very Low", "Low", "Low to Moderate"},
 		cloudinfo.NtwMedium: {"Moderate", "High"},
 		cloudinfo.NtwHight:  {"Up to 10 Gigabit", "10 Gigabit"},
 		cloudinfo.NtwExtra:  {"20 Gigabit", "25 Gigabit", "Up to 25 Gigabit", "50 Gigabit", "100 Gigabit"},

--- a/pkg/cloudinfo/amazon/network_mapper_test.go
+++ b/pkg/cloudinfo/amazon/network_mapper_test.go
@@ -34,7 +34,7 @@ func TestEc2NetworkMapper_MapNetworkPerf(t *testing.T) {
 				NtwPerf: "Very Low",
 			},
 			check: func(cat string, err error) {
-				assert.Equal(t, cloudinfo.NetwLow, cat, "not mapped to the right category")
+				assert.Equal(t, cloudinfo.NtwLow, cat, "not mapped to the right category")
 			},
 		},
 		{

--- a/pkg/cloudinfo/azure/category_mapper.go
+++ b/pkg/cloudinfo/azure/category_mapper.go
@@ -40,7 +40,7 @@ func newAzureCategoryMapper() *AzureCategoryMapper {
 	return &AzureCategoryMapper{}
 }
 
-// MapCategory maps the family of the azure instance to the category supported by telescopes
+// MapCategory maps the family of the azure instance to category
 func (nm *AzureCategoryMapper) MapCategory(name string) (string, error) {
 	family := strings.TrimRight(name, "Family")
 	family = strings.TrimLeft(family, "standard")

--- a/pkg/cloudinfo/azure/category_mapper.go
+++ b/pkg/cloudinfo/azure/category_mapper.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo"
+	"github.com/goph/emperror"
 	"github.com/pkg/errors"
 )
 
@@ -31,17 +32,8 @@ var (
 	}
 )
 
-// AzureCategoryMapper module object for sort virtual machines into categories
-type AzureCategoryMapper struct {
-}
-
-// newAzureCategoryMapper initializes the category mapper struct
-func newAzureCategoryMapper() *AzureCategoryMapper {
-	return &AzureCategoryMapper{}
-}
-
-// MapCategory maps the family of the azure instance to category
-func (nm *AzureCategoryMapper) MapCategory(name string) (string, error) {
+// mapCategory maps the family of the azure instance to category
+func (a *AzureInfoer) mapCategory(name string) (string, error) {
 	family := strings.TrimRight(name, "Family")
 	family = strings.TrimLeft(family, "standard")
 	family = strings.TrimRight(family, "Promo")
@@ -52,5 +44,5 @@ func (nm *AzureCategoryMapper) MapCategory(name string) (string, error) {
 			return category, nil
 		}
 	}
-	return "", errors.Wrap(errors.New(family), "could not determine the category")
+	return "", emperror.Wrap(errors.New(family), "could not determine the category")
 }

--- a/pkg/cloudinfo/azure/category_mapper.go
+++ b/pkg/cloudinfo/azure/category_mapper.go
@@ -1,0 +1,56 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import (
+	"strings"
+
+	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo"
+	"github.com/pkg/errors"
+)
+
+var (
+	categoryMap = map[string][]string{
+		cloudinfo.CategoryGeneral: {"Dv2", "Av2", "Dv3", "DSv2", "DSv3", "BS", "DS", "D", "A0_A7", "A", "A8_A11", "DCS"},
+		cloudinfo.CategoryCompute: {"H", "FSv2", "FS", "", "HCS", "HBS"},
+		cloudinfo.CategoryMemory:  {"Ev3", "ESv3", "MS", "G", "GS", "EIv3", "EISv3"},
+		cloudinfo.CategoryStorage: {"LS", "LSv2"},
+		cloudinfo.CategoryGpu:     {"NC", "NV", "NCSv3", "NCSv2", "NDS", "NVSv2"},
+	}
+)
+
+// AzureCategoryMapper module object for sort virtual machines into categories
+type AzureCategoryMapper struct {
+}
+
+// newAzureCategoryMapper initializes the category mapper struct
+func newAzureCategoryMapper() *AzureCategoryMapper {
+	return &AzureCategoryMapper{}
+}
+
+// MapCategory maps the family of the azure instance to the category supported by telescopes
+func (nm *AzureCategoryMapper) MapCategory(name string) (string, error) {
+	family := strings.TrimRight(name, "Family")
+	family = strings.TrimLeft(family, "standard")
+	family = strings.TrimRight(family, "Promo")
+	family = strings.TrimLeft(family, "basic")
+
+	for category, strVals := range categoryMap {
+		if cloudinfo.Contains(strVals, family) {
+			return category, nil
+		}
+	}
+	return "", errors.Wrap(errors.New(family), "could not determine the category")
+}

--- a/pkg/cloudinfo/azure/cloudinfo.go
+++ b/pkg/cloudinfo/azure/cloudinfo.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/goph/emperror"
 	"io/ioutil"
 	"os"
 	"regexp"
@@ -36,6 +35,7 @@ import (
 	"github.com/banzaicloud/cloudinfo/internal/platform/log"
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo"
 	"github.com/banzaicloud/cloudinfo/pkg/cloudinfo/metrics"
+	"github.com/goph/emperror"
 	"github.com/goph/logur"
 	"github.com/pkg/errors"
 )
@@ -375,8 +375,7 @@ func (a *AzureInfoer) getCategory(vms []cloudinfo.VmInfo, log logur.Logger) ([]c
 			if *sku.ResourceType == "virtualMachines" {
 				if *sku.Name == vm.Type {
 
-					categoryMapper := newAzureCategoryMapper()
-					category, err := categoryMapper.MapCategory(*sku.Family)
+					category, err := a.mapCategory(*sku.Family)
 					if err != nil {
 						log.Debug(emperror.Wrap(err, "failed to get virtual machine category").Error(),
 							map[string]interface{}{"instanceType": vm.Type})

--- a/pkg/cloudinfo/azure/cloudinfo.go
+++ b/pkg/cloudinfo/azure/cloudinfo.go
@@ -383,10 +383,11 @@ func (a *AzureInfoer) getCategory(vms []cloudinfo.VmInfo, log logur.Logger) ([]c
 					}
 
 					virtualMachines = append(virtualMachines, cloudinfo.VmInfo{
-						Category: category,
-						Type:     vm.Type,
-						Mem:      vm.Mem,
-						Cpus:     vm.Cpus,
+						Category:   category,
+						Type:       vm.Type,
+						Mem:        vm.Mem,
+						Cpus:       vm.Cpus,
+						Attributes: cloudinfo.Attributes(fmt.Sprint(vm.Mem), fmt.Sprint(vm.Cpus), "unknown", category),
 					})
 					break
 				}
@@ -406,10 +407,9 @@ func (a *AzureInfoer) GetVirtualMachines(region string) ([]cloudinfo.VmInfo, err
 	}
 	for _, v := range *vmSizes.Value {
 		vms = append(vms, cloudinfo.VmInfo{
-			Type:       *v.Name,
-			Cpus:       float64(*v.NumberOfCores),
-			Mem:        float64(*v.MemoryInMB) / 1024,
-			Attributes: cloudinfo.Attributes(fmt.Sprint(*v.NumberOfCores), fmt.Sprint(float64(*v.MemoryInMB)/1024), "unknown"),
+			Type: *v.Name,
+			Cpus: float64(*v.NumberOfCores),
+			Mem:  float64(*v.MemoryInMB) / 1024,
 			// TODO: netw perf
 		})
 	}

--- a/pkg/cloudinfo/azure/cloudinfo.go
+++ b/pkg/cloudinfo/azure/cloudinfo.go
@@ -18,12 +18,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/goph/emperror"
 	"io/ioutil"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2017-09-01/skus"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2018-03-31/containerservice"
 	"github.com/Azure/azure-sdk-for-go/services/preview/commerce/mgmt/2015-06-01-preview/commerce"
@@ -68,16 +70,7 @@ var (
 )
 
 type authentication struct {
-	ClientID                string `json:"clientId,omitempty"`
-	ClientSecret            string `json:"clientSecret,omitempty"`
-	SubscriptionID          string `json:"subscriptionId,omitempty"`
-	TenantID                string `json:"tenantId,omitempty"`
-	ActiveDirectoryEndpoint string `json:"activeDirectoryEndpointUrl,omitempty"`
-	ResourceManagerEndpoint string `json:"resourceManagerEndpointUrl,omitempty"`
-	GraphResourceID         string `json:"activeDirectoryGraphResourceId,omitempty"`
-	SQLManagementEndpoint   string `json:"sqlManagementEndpointUrl,omitempty"`
-	GalleryEndpoint         string `json:"galleryEndpointUrl,omitempty"`
-	ManagementEndpoint      string `json:"managementEndpointUrl,omitempty"`
+	SubscriptionID string `json:"subscriptionId,omitempty"`
 }
 
 // AzureInfoer encapsulates the data and operations needed to access external Azure resources
@@ -86,6 +79,7 @@ type AzureInfoer struct {
 	subscriptionsClient LocationRetriever
 	vmSizesClient       VmSizesRetriever
 	rateCardClient      PriceRetriever
+	skusClient          CategoryRetriever
 	providersClient     ProviderSource
 	containerSvcClient  VersionRetriever
 	log                 logur.Logger
@@ -116,6 +110,11 @@ type VersionRetriever interface {
 	ListOrchestrators(ctx context.Context, location string, resourceType string) (result containerservice.OrchestratorVersionProfileListResult, err error)
 }
 
+// CategoryRetriever collects virtual machines family
+type CategoryRetriever interface {
+	List(ctx context.Context) (result skus.ResourceSkusResultPage, err error)
+}
+
 // newInfoer creates a new instance of the Azure infoer
 func newInfoer(authLocation string, log logur.Logger) (*AzureInfoer, error) {
 	err := os.Setenv("AZURE_AUTH_LOCATION", authLocation)
@@ -132,8 +131,8 @@ func newInfoer(authLocation string, log logur.Logger) (*AzureInfoer, error) {
 	if err != nil {
 		return nil, err
 	}
-	auth := authentication{}
-	err = json.Unmarshal(contents, &auth)
+	a := authentication{}
+	err = json.Unmarshal(contents, &a)
 	if err != nil {
 		return nil, err
 	}
@@ -141,22 +140,26 @@ func newInfoer(authLocation string, log logur.Logger) (*AzureInfoer, error) {
 	sClient := subscriptions.NewClient()
 	sClient.Authorizer = authorizer
 
-	vmClient := compute.NewVirtualMachineSizesClient(auth.SubscriptionID)
+	vmClient := compute.NewVirtualMachineSizesClient(a.SubscriptionID)
 	vmClient.Authorizer = authorizer
 
-	rcClient := commerce.NewRateCardClient(auth.SubscriptionID)
+	rcClient := commerce.NewRateCardClient(a.SubscriptionID)
 	rcClient.Authorizer = authorizer
 
-	providersClient := resources.NewProvidersClient(auth.SubscriptionID)
+	skusClient := skus.NewResourceSkusClient(a.SubscriptionID)
+	skusClient.Authorizer = authorizer
+
+	providersClient := resources.NewProvidersClient(a.SubscriptionID)
 	providersClient.Authorizer = authorizer
 
-	containerServiceClient := containerservice.NewContainerServicesClient(auth.SubscriptionID)
+	containerServiceClient := containerservice.NewContainerServicesClient(a.SubscriptionID)
 	containerServiceClient.Authorizer = authorizer
 
 	return &AzureInfoer{
-		subscriptionId:      auth.SubscriptionID,
+		subscriptionId:      a.SubscriptionID,
 		subscriptionsClient: sClient,
 		vmSizesClient:       vmClient,
+		skusClient:          skusClient,
 		rateCardClient:      rcClient,
 		providersClient:     providersClient,
 		containerSvcClient:  &containerServiceClient,
@@ -233,7 +236,7 @@ func (a *AzureInfoer) Initialize() (map[string]map[string]cloudinfo.Price, error
 			if !strings.Contains(*v.MeterSubCategory, "Windows") {
 				region, err := a.toRegionID(*v.MeterRegion, regions)
 				if err != nil {
-					missingRegions = append(missingRegions, *v.MeterRegion)
+					missingRegions = appendIfMissing(missingRegions, *v.MeterRegion)
 					continue
 				}
 
@@ -360,9 +363,42 @@ func (a *AzureInfoer) addSuffix(mt string, suffixes ...string) []string {
 	return result
 }
 
+func (a *AzureInfoer) getCategory(vms []cloudinfo.VmInfo, log logur.Logger) ([]cloudinfo.VmInfo, error) {
+	skusResultPage, err := a.skusClient.List(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	var virtualMachines []cloudinfo.VmInfo
+	for _, vm := range vms {
+		for _, sku := range skusResultPage.Values() {
+			if *sku.ResourceType == "virtualMachines" {
+				if *sku.Name == vm.Type {
+
+					categoryMapper := newAzureCategoryMapper()
+					category, err := categoryMapper.MapCategory(*sku.Family)
+					if err != nil {
+						log.Debug(emperror.Wrap(err, "failed to get virtual machine category").Error(),
+							map[string]interface{}{"instanceType": vm.Type})
+					}
+
+					virtualMachines = append(virtualMachines, cloudinfo.VmInfo{
+						Category: category,
+						Type:     vm.Type,
+						Mem:      vm.Mem,
+						Cpus:     vm.Cpus,
+					})
+					break
+				}
+			}
+		}
+	}
+	return virtualMachines, nil
+}
+
 func (a *AzureInfoer) GetVirtualMachines(region string) ([]cloudinfo.VmInfo, error) {
-	log := log.WithFields(a.log, map[string]interface{}{"region": region})
-	log.Debug("getting product info")
+	logger := log.WithFields(a.log, map[string]interface{}{"region": region})
+	logger.Debug("getting product info")
 	var vms []cloudinfo.VmInfo
 	vmSizes, err := a.vmSizesClient.List(context.TODO(), region)
 	if err != nil {
@@ -378,8 +414,13 @@ func (a *AzureInfoer) GetVirtualMachines(region string) ([]cloudinfo.VmInfo, err
 		})
 	}
 
-	log.Debug("found virtual machines", map[string]interface{}{"numberOfVms": len(vms)})
-	return vms, nil
+	virtualMachines, err := a.getCategory(vms, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Debug("found virtual machines", map[string]interface{}{"numberOfVms": len(vms)})
+	return virtualMachines, nil
 }
 
 // GetProducts retrieves the available virtual machines based on the arguments provided
@@ -409,8 +450,8 @@ func (a *AzureInfoer) GetZones(region string) ([]string, error) {
 
 // GetRegions returns a map with available regions transforms the api representation into a "plain" map
 func (a *AzureInfoer) GetRegions(service string) (map[string]string, error) {
-	log := log.WithFields(a.log, map[string]interface{}{"service": service})
-	log.Debug("getting locations")
+	logger := log.WithFields(a.log, map[string]interface{}{"service": service})
+	logger.Debug("getting locations")
 
 	allLocations := make(map[string]string)
 	supLocations := make(map[string]string)
@@ -422,7 +463,7 @@ func (a *AzureInfoer) GetRegions(service string) (map[string]string, error) {
 			allLocations[*loc.DisplayName] = *loc.Name
 		}
 	} else {
-		log.Error("error while retrieving azure locations")
+		logger.Error("error while retrieving azure locations")
 		return nil, err
 	}
 
@@ -443,18 +484,18 @@ func (a *AzureInfoer) GetRegions(service string) (map[string]string, error) {
 						if loc, ok := allLocations[displName]; ok {
 							supLocations[loc] = displName
 						} else {
-							log.Debug("unsupported location", map[string]interface{}{"name": loc, "displayname": displName})
+							logger.Debug("unsupported location", map[string]interface{}{"name": loc, "displayname": displName})
 						}
 					}
 					break
 				}
 			}
 		} else {
-			log.Error("failed to retrieve supported locations", map[string]interface{}{"resource": resourceTypeForAks})
+			logger.Error("failed to retrieve supported locations", map[string]interface{}{"resource": resourceTypeForAks})
 			return nil, err
 		}
 
-		log.Debug("found supported locations", map[string]interface{}{"numberOfLocations": len(supLocations)})
+		logger.Debug("found supported locations", map[string]interface{}{"numberOfLocations": len(supLocations)})
 		return supLocations, nil
 	default:
 		if providers, err := a.providersClient.Get(context.TODO(), providerNamespaceForCompute, ""); err == nil {
@@ -464,18 +505,18 @@ func (a *AzureInfoer) GetRegions(service string) (map[string]string, error) {
 						if loc, ok := allLocations[displName]; ok {
 							supLocations[loc] = displName
 						} else {
-							log.Debug("unsupported location", map[string]interface{}{"name": loc, "displayname": displName})
+							logger.Debug("unsupported location", map[string]interface{}{"name": loc, "displayname": displName})
 						}
 					}
 					break
 				}
 			}
 		} else {
-			log.Error("failed to retrieve supported locations", map[string]interface{}{"resource": resourceTypeForCompute})
+			logger.Error("failed to retrieve supported locations", map[string]interface{}{"resource": resourceTypeForCompute})
 			return nil, err
 		}
 
-		log.Debug("found supported locations", map[string]interface{}{"numberOfLocations": len(supLocations)})
+		logger.Debug("found supported locations", map[string]interface{}{"numberOfLocations": len(supLocations)})
 		return supLocations, nil
 	}
 }

--- a/pkg/cloudinfo/azure/cloudinfo_test.go
+++ b/pkg/cloudinfo/azure/cloudinfo_test.go
@@ -540,39 +540,6 @@ func TestAzureInfoer_getMachineTypeVariants(t *testing.T) {
 	}
 }
 
-func TestAzureInfoer_GetVirtualMachines(t *testing.T) {
-	tests := []struct {
-		name    string
-		vmSizes VmSizesRetriever
-		check   func(vms []cloudinfo.VmInfo, err error)
-	}{
-		{
-			name:    "retrieve the available virtual machines",
-			vmSizes: &testStruct{},
-			check: func(vms []cloudinfo.VmInfo, err error) {
-				assert.Nil(t, err, "the error should be nil")
-				var cpus []float64
-				var mems []float64
-
-				for _, vm := range vms {
-					cpus = append(cpus, vm.Cpus)
-					mems = append(mems, vm.Mem)
-				}
-				assert.ElementsMatch(t, cpus, []float64{1, 4, 8})
-				assert.ElementsMatch(t, mems, []float64{2, 32, 32})
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			azureInfoer := AzureInfoer{log: logur.NewTestLogger()}
-
-			azureInfoer.vmSizesClient = test.vmSizes
-			test.check(azureInfoer.GetVirtualMachines("dummyRegion"))
-		})
-	}
-}
-
 func TestAzureInfoer_GetProducts(t *testing.T) {
 	vms := []cloudinfo.VmInfo{
 		{

--- a/pkg/cloudinfo/azure/network_mapper.go
+++ b/pkg/cloudinfo/azure/network_mapper.go
@@ -21,7 +21,7 @@ import (
 var (
 	// TODO
 	ntwPerfMap = map[string][]string{
-		cloudinfo.NetwLow:   {"Low"},
+		cloudinfo.NtwLow:    {"Low"},
 		cloudinfo.NtwMedium: {"Moderate"},
 		cloudinfo.NtwHight:  {""},
 	}

--- a/pkg/cloudinfo/cloudinfo.go
+++ b/pkg/cloudinfo/cloudinfo.go
@@ -256,12 +256,13 @@ func Contains(slice []string, s string) bool {
 }
 
 // Attributes create a map with the specified parameters
-func Attributes(cpu, memory, ntwPerfCat string) map[string]string {
+func Attributes(cpu, memory, ntwPerfCat, vmCategory string) map[string]string {
 	var attributes = make(map[string]string)
 
 	attributes[Cpu] = cpu
 	attributes[Memory] = memory
 	attributes["networkPerfCategory"] = ntwPerfCat
+	attributes["instanceTypeCategory"] = vmCategory
 
 	return attributes
 }

--- a/pkg/cloudinfo/cloudinfo.go
+++ b/pkg/cloudinfo/cloudinfo.go
@@ -49,6 +49,7 @@ type Price struct {
 
 // VmInfo representation of a virtual machine
 type VmInfo struct {
+	Category      string            `json:"category"`
 	Type          string            `json:"type"`
 	OnDemandPrice float64           `json:"onDemandPrice"`
 	SpotPrice     []ZonePrice       `json:"spotPrice"`

--- a/pkg/cloudinfo/google/cloudinfo.go
+++ b/pkg/cloudinfo/google/cloudinfo.go
@@ -300,7 +300,7 @@ func (g *GceInfoer) GetVirtualMachines(region string) ([]cloudinfo.VmInfo, error
 					NtwPerf:    fmt.Sprintf("%d Gbit/s", ntwPerf),
 					NtwPerfCat: ntwPerfCat,
 					Zones:      zones,
-					Attributes: cloudinfo.Attributes(fmt.Sprint(mt.GuestCpus), fmt.Sprint(float64(mt.MemoryMb)/1024), ntwPerfCat),
+					Attributes: cloudinfo.Attributes(fmt.Sprint(mt.GuestCpus), fmt.Sprint(float64(mt.MemoryMb)/1024), ntwPerfCat, g.getCategory(mt.Name)),
 				}
 			}
 		}

--- a/pkg/cloudinfo/google/network_mapper.go
+++ b/pkg/cloudinfo/google/network_mapper.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	ntwPerfMap = map[string][]string{
-		cloudinfo.NetwLow:   {"1 Gbit/s", "2 Gbit/s"},
+		cloudinfo.NtwLow:    {"1 Gbit/s", "2 Gbit/s"},
 		cloudinfo.NtwMedium: {"4 Gbit/s", "6 Gbit/s", "8 Gbit/s"},
 		cloudinfo.NtwHight:  {"10 Gbit/s", "12 Gbit/s", "14 Gbit/s"},
 		cloudinfo.NtwExtra:  {"16 Gbit/s"},

--- a/pkg/cloudinfo/oracle/cloudinfo.go
+++ b/pkg/cloudinfo/oracle/cloudinfo.go
@@ -111,7 +111,7 @@ func (i *Infoer) GetProductPrice(specs ShapeSpecs) (price float64, err error) {
 }
 
 func (i *Infoer) GetVirtualMachines(region string) (products []cloudinfo.VmInfo, err error) {
-	log := log.WithFields(i.log, map[string]interface{}{"region": region})
+	logger := log.WithFields(i.log, map[string]interface{}{"region": region})
 
 	err = i.client.ChangeRegion(region)
 	if err != nil {
@@ -134,7 +134,7 @@ func (i *Infoer) GetVirtualMachines(region string) (products []cloudinfo.VmInfo,
 		ntwMapper := newNetworkMapper()
 		ntwPerfCat, err := ntwMapper.MapNetworkPerf(fmt.Sprint(s.NtwPerf))
 		if err != nil {
-			log.Debug(emperror.Wrap(err, "failed to get network performance category").Error(),
+			logger.Debug(emperror.Wrap(err, "failed to get network performance category").Error(),
 				map[string]interface{}{"instanceType": shape})
 		}
 
@@ -144,6 +144,7 @@ func (i *Infoer) GetVirtualMachines(region string) (products []cloudinfo.VmInfo,
 		}
 
 		products = append(products, cloudinfo.VmInfo{
+			Category:      cloudinfo.CategoryMemory,
 			Type:          shape,
 			OnDemandPrice: price,
 			NtwPerf:       s.NtwPerf,
@@ -160,7 +161,7 @@ func (i *Infoer) GetVirtualMachines(region string) (products []cloudinfo.VmInfo,
 
 // GetProducts retrieves the available virtual machines types in a region
 func (i *Infoer) GetProducts(vms []cloudinfo.VmInfo, service, regionId string) (products []cloudinfo.VmInfo, err error) {
-	log := log.WithFields(i.log, map[string]interface{}{"service": service, "region": regionId})
+	logger := log.WithFields(i.log, map[string]interface{}{"service": service, "region": regionId})
 
 	err = i.client.ChangeRegion(regionId)
 	if err != nil {
@@ -183,7 +184,7 @@ func (i *Infoer) GetProducts(vms []cloudinfo.VmInfo, service, regionId string) (
 		ntwMapper := newNetworkMapper()
 		ntwPerfCat, err := ntwMapper.MapNetworkPerf(fmt.Sprint(s.NtwPerf))
 		if err != nil {
-			log.Debug(emperror.Wrap(err, "failed to get network performance category").Error(),
+			logger.Debug(emperror.Wrap(err, "failed to get network performance category").Error(),
 				map[string]interface{}{"instanceType": shape})
 		}
 
@@ -209,8 +210,8 @@ func (i *Infoer) GetProducts(vms []cloudinfo.VmInfo, service, regionId string) (
 
 // GetRegions returns a map with available regions
 func (i *Infoer) GetRegions(service string) (regions map[string]string, err error) {
-	log := log.WithFields(i.log, map[string]interface{}{"service": service})
-	log.Debug("getting regions")
+	logger := log.WithFields(i.log, map[string]interface{}{"service": service})
+	logger.Debug("getting regions")
 
 	c, err := i.client.NewIdentityClient()
 	if err != nil {
@@ -231,14 +232,14 @@ func (i *Infoer) GetRegions(service string) (regions map[string]string, err erro
 		regions[region] = description
 	}
 
-	log.Debug("found regions", map[string]interface{}{"numberOfRegions": len(regions)})
+	logger.Debug("found regions", map[string]interface{}{"numberOfRegions": len(regions)})
 	return
 }
 
 // GetZones returns the availability zones in a region
 func (i *Infoer) GetZones(region string) (zones []string, err error) {
-	log := log.WithFields(i.log, map[string]interface{}{"region": region})
-	log.Debug("getting zones")
+	logger := log.WithFields(i.log, map[string]interface{}{"region": region})
+	logger.Debug("getting zones")
 
 	err = i.client.ChangeRegion(region)
 	if err != nil {
@@ -259,7 +260,7 @@ func (i *Infoer) GetZones(region string) (zones []string, err error) {
 		zones = append(zones, *ad.Name)
 	}
 
-	log.Debug("found zones", map[string]interface{}{"numberOfZones": len(zones)})
+	logger.Debug("found zones", map[string]interface{}{"numberOfZones": len(zones)})
 	return
 }
 

--- a/pkg/cloudinfo/oracle/cloudinfo.go
+++ b/pkg/cloudinfo/oracle/cloudinfo.go
@@ -152,7 +152,7 @@ func (i *Infoer) GetVirtualMachines(region string) (products []cloudinfo.VmInfo,
 			Cpus:          s.Cpus,
 			Mem:           s.Mem,
 			Zones:         zones,
-			Attributes:    cloudinfo.Attributes(fmt.Sprint(s.Cpus), fmt.Sprint(s.Mem), ntwPerfCat),
+			Attributes:    cloudinfo.Attributes(fmt.Sprint(s.Cpus), fmt.Sprint(s.Mem), ntwPerfCat, cloudinfo.CategoryMemory),
 		})
 	}
 
@@ -194,6 +194,7 @@ func (i *Infoer) GetProducts(vms []cloudinfo.VmInfo, service, regionId string) (
 		}
 
 		products = append(products, cloudinfo.VmInfo{
+			Category:      cloudinfo.CategoryMemory,
 			Type:          shape,
 			OnDemandPrice: price,
 			NtwPerf:       s.NtwPerf,
@@ -201,7 +202,7 @@ func (i *Infoer) GetProducts(vms []cloudinfo.VmInfo, service, regionId string) (
 			Cpus:          s.Cpus,
 			Mem:           s.Mem,
 			Zones:         zones,
-			Attributes:    cloudinfo.Attributes(fmt.Sprint(s.Cpus), fmt.Sprint(s.Mem), ntwPerfCat),
+			Attributes:    cloudinfo.Attributes(fmt.Sprint(s.Cpus), fmt.Sprint(s.Mem), ntwPerfCat, cloudinfo.CategoryMemory),
 		})
 	}
 

--- a/pkg/cloudinfo/oracle/network_mapper.go
+++ b/pkg/cloudinfo/oracle/network_mapper.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	ntwPerfMap = map[string][]string{
-		cloudinfo.NetwLow:   {"0.6 Gbps"},
+		cloudinfo.NtwLow:    {"0.6 Gbps"},
 		cloudinfo.NtwMedium: {"1 Gbps", "1.2 Gbps", "2 Gbps", "2.4 Gbps"},
 		cloudinfo.NtwHight:  {"4.1 Gbps", "4.8 Gbps", "8.2 Gbps"},
 		cloudinfo.NtwExtra:  {"16.4 Gbps", "24.6 Gbps"},

--- a/pkg/cloudinfo/types.go
+++ b/pkg/cloudinfo/types.go
@@ -68,14 +68,22 @@ type AttrValues []AttrValue
 var (
 	// telescope supported network performance of vm-s
 
-	// NetwLow the low network performance category
-	NetwLow = "low"
+	// NtwLow the low network performance category
+	NtwLow = "low"
 	// NtwMedium the medium network performance category
 	NtwMedium = "medium"
 	// NtwHight the high network performance category
 	NtwHight = "high"
 	// NtwExtra the highest network performance category
 	NtwExtra = "extra"
+
+	// Telescopes supports categories of virtual machines
+
+	CategoryGeneral = "General purpose"
+	CategoryCompute = "Compute optimized"
+	CategoryMemory  = "Memory optimized"
+	CategoryGpu     = "GPU instance"
+	CategoryStorage = "Storage optimized"
 )
 
 // NetworkPerfMapper operations related  to mapping between virtual machines to network performance categories


### PR DESCRIPTION
Classify instance types into 5 different categories (General purpose, Compute optimized, Memory optimized, GPU instance, Storage optimized). Telescopes will be able to filter by category.