### PR TITLE
remove supported k8s versions 1.10, 1.11 for eks

### DIFF
--- a/main-targets.mk
+++ b/main-targets.mk
@@ -58,7 +58,7 @@ docker: ## Build a Docker image
 ifneq (${DOCKER_PREBUILT}, 1)
 	@${MAKE} BINARY_NAME="${BINARY_NAME}-linux-amd64" GOOS=linux GOARCH=amd64 build-release
 endif
-	docker build --build-arg BUILD_DIR=${BUILD_DIR}/release --build-arg BINARY_NAME=${BINARY_NAME}-linux-amd64 -t ${DOCKER_IMAGE}:${DOCKER_TAG} -f Dockerfile.local .
+	docker build --build-arg BUILD_DIR=${BUILD_DIR}/release --build-arg BINARY_NAME=${BINARY_NAME}-linux-amd64 -t ${DOCKER_IMAGE}:${DOCKER_TAG} -f Dockerfile .
 ifeq (${DOCKER_LATEST}, 1)
 	docker tag ${DOCKER_IMAGE}:${DOCKER_TAG} ${DOCKER_IMAGE}:latest
 endif

--- a/pkg/cloudinfo/amazon/cloudinfo.go
+++ b/pkg/cloudinfo/amazon/cloudinfo.go
@@ -536,7 +536,7 @@ func (e *Ec2Infoer) GetServiceImages(service, region string) ([]cloudinfo.Image,
 	imageDescribers := make([]cloudinfo.Image, 0)
 
 	if service == "_eks" {
-		for _, version := range []string{"1.10", "1.11", "1.12", "1.13"} {
+		for _, version := range []string{"1.12", "1.13"} {
 			input := &ec2.DescribeImagesInput{
 				Filters: []*ec2.Filter{
 					{


### PR DESCRIPTION
* remove supported k8s versions 1.10, 1.11 for eks (some of the spotguides require higher k8s versions) 
