### PR TITLE
Build docker image with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
     helm: banzaicloud/helm@0.0.3
+    docker: circleci/docker@0.5.13
 
 executors:
     docker:
@@ -163,6 +164,70 @@ jobs:
                 store_test_results:
                     path: build/test_results/
 
+    docker-release:
+        executor: docker/machine
+        parameters:
+            tag:
+               default: $CIRCLE_SHA1
+               description: 'Image tag'
+               type: string
+            extra_build_args:
+               default: ''
+               description: >
+                   Extra flags to pass to docker build. For examples
+               type: string
+            image:
+                description: Name of image to build
+                type: string
+            registry:
+                default: docker.io
+                description: |
+                    Name of registry to use, defaults to docker.io
+                type: string
+        steps:
+            - checkout
+            - docker/check
+
+            -
+                docker/build:
+                    extra_build_args: <<parameters.extra_build_args>>
+                    registry: <<parameters.registry>>
+                    image: <<parameters.image>>
+                    tag: $CIRCLE_SHA1
+
+            -
+                run:
+                    name: Tag release
+                    command: |
+                        docker tag <<parameters.image>>:$CIRCLE_SHA1 <<parameters.registry>>/<<parameters.image>>:<< parameters.tag >>
+
+            -
+                docker/push:
+                    registry: <<parameters.registry>>
+                    image: <<parameters.image>>
+                    tag: $CIRCLE_TAG
+
+            -
+                run:
+                    name: Check version
+                    command: |
+                      if ! echo "${CIRCLE_TAG}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+                        echo 'Unstable version. Skipping further steps.'
+                        circleci step halt
+                      fi
+
+            -
+                run:
+                    name: Tag latest
+                    command: |
+                      docker tag <<parameters.image>>:$CIRCLE_SHA1 <<parameters.registry>>/<<parameters.image>>:latest
+
+            -
+                docker/push:
+                    registry: <<parameters.registry>>
+                    image: <<parameters.image>>
+                    tag: latest
+
 workflows:
     version: 2
     ci:
@@ -180,6 +245,41 @@ workflows:
             - integration-tests:
                   requires:
                       - dependencies
+            - docker/publish:
+                    name: Build docker image
+                    deploy: false
+                    extra_build_args: '--build-arg GOPROXY=https://proxy.golang.org'
+                    image: banzaicloud/cloudinfo
+                    tag: $CIRCLE_BRANCH
+                    filters:
+                        branches:
+                            ignore: master
+            - docker/publish:
+                    name: Publish master docker image
+                    context: dockerhub
+                    deploy: true
+                    extra_build_args: '--build-arg GOPROXY=https://proxy.golang.org'
+                    image: banzaicloud/cloudinfo
+                    tag: master
+                    requires:
+                      - build
+                      - static-checks
+                      - unit-tests
+                      - integration-tests
+                    filters:
+                        branches:
+                            only: master
+            - docker-release:
+                  name: Publish tagged & latest docker image
+                  context: dockerhub
+                  extra_build_args: '--build-arg GOPROXY=https://proxy.golang.org'
+                  image: banzaicloud/cloudinfo
+                  tag: $CIRCLE_TAG
+                  filters:
+                      tags:
+                          only: /^[0-9]+\.[0-9]+\.[0-9]+(?:-(?:dev|rc)\.[0-9]+)?$/
+                      branches:
+                          ignore: /.*/
 
     helm-chart:
         jobs:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #265
| License         | Apache 2.0


### What's in this PR?
Replace Docker Hub's auto build.
```
master -> banzaicloud/cloudinfo:master
tag    -> banzaicloud/cloudinfo:<tag> & banzaicloud/cloudinfo:latest
branch -> only build
```

### To Do
- [ ] Disable auto build on Docker Hub