### PR TITLE
Pke loader fix

### DIFF
--- a/internal/app/cloudinfo/loader/data.go
+++ b/internal/app/cloudinfo/loader/data.go
@@ -65,6 +65,17 @@ type VmData struct {
 	Data     []types.VMInfo
 }
 
+func (wmd VmData) ContainsVM(VMType string) bool {
+	for _, VMInfo := range wmd.Data {
+		if VMInfo.Type == VMType {
+			
+			return true
+		}
+	}
+
+	return false
+}
+
 type Service struct {
 	Name         string
 	IsStatic     bool

--- a/internal/app/cloudinfo/loader/data.go
+++ b/internal/app/cloudinfo/loader/data.go
@@ -68,7 +68,7 @@ type VmData struct {
 func (wmd VmData) ContainsVM(VMType string) bool {
 	for _, VMInfo := range wmd.Data {
 		if VMInfo.Type == VMType {
-			
+
 			return true
 		}
 	}

--- a/internal/app/cloudinfo/loader/loader.go
+++ b/internal/app/cloudinfo/loader/loader.go
@@ -358,16 +358,10 @@ func (sl *storeCloudInfoLoader) LoadVms(provider string, service string, region 
 		filteredVMs := make([]types.VMInfo, 0, len(sourceVMs))
 		for _, sourceVM := range sourceVMs {
 
-			for _, excludeVM := range region.Data.Vms.Data {
-				if sourceVM.Type == excludeVM.Type {
-					// skip excluded values
-					continue
-				}
-
+			if !region.Data.Vms.ContainsVM(sourceVM.Type) {
 				// only append values that are not excluded
 				filteredVMs = append(filteredVMs, sourceVM)
 			}
-
 		}
 
 		sl.store.StoreVm(provider, service, region.Id, filteredVMs)
@@ -388,11 +382,7 @@ func (sl *storeCloudInfoLoader) LoadVms(provider string, service string, region 
 		filteredVMs := make([]types.VMInfo, 0, len(sourceVMs))
 		for _, sourceVM := range sourceVMs {
 
-			for _, includeVM := range region.Data.Vms.Data {
-				if sourceVM.Type != includeVM.Type {
-					continue
-				}
-
+			if region.Data.Vms.ContainsVM(sourceVM.Type) {
 				// only append included values
 				filteredVMs = append(filteredVMs, sourceVM)
 			}

--- a/internal/app/cloudinfo/loader/loader.go
+++ b/internal/app/cloudinfo/loader/loader.go
@@ -349,6 +349,12 @@ func (sl *storeCloudInfoLoader) LoadVms(provider string, service string, region 
 			return
 		}
 
+		// there are no exclusions
+		if len(region.Data.Vms.Data) == 0 {
+			sl.store.StoreVm(provider, service, region.Id, sourceVMs)
+			return
+		}
+
 		filteredVMs := make([]types.VMInfo, 0, len(sourceVMs))
 		for _, sourceVM := range sourceVMs {
 

--- a/internal/app/cloudinfo/loader/loader.go
+++ b/internal/app/cloudinfo/loader/loader.go
@@ -349,12 +349,6 @@ func (sl *storeCloudInfoLoader) LoadVms(provider string, service string, region 
 			return
 		}
 
-		// there are no exclusions
-		if len(region.Data.Vms.Data) == 0 {
-			sl.store.StoreVm(provider, service, region.Id, sourceVMs)
-			return
-		}
-
 		filteredVMs := make([]types.VMInfo, 0, len(sourceVMs))
 		for _, sourceVM := range sourceVMs {
 
@@ -370,12 +364,6 @@ func (sl *storeCloudInfoLoader) LoadVms(provider string, service string, region 
 		sourceVMs, ok := sl.store.GetVm(provider, sl.serviceData.Source, region.Id)
 		if !ok {
 			log.Warn("source service VMs not yet cached", map[string]interface{}{"source": sl.serviceData.Source})
-			return
-		}
-
-		// there are no inclusions
-		if len(region.Data.Vms.Data) == 0 {
-			sl.store.StoreVm(provider, service, region.Id, sourceVMs)
 			return
 		}
 

--- a/internal/app/cloudinfo/loader/loader.go
+++ b/internal/app/cloudinfo/loader/loader.go
@@ -374,6 +374,12 @@ func (sl *storeCloudInfoLoader) LoadVms(provider string, service string, region 
 			return
 		}
 
+		// there are no inclusions
+		if len(region.Data.Vms.Data) == 0 {
+			sl.store.StoreVm(provider, service, region.Id, sourceVMs)
+			return
+		}
+
 		filteredVMs := make([]types.VMInfo, 0, len(sourceVMs))
 		for _, sourceVM := range sourceVMs {
 

--- a/internal/app/cloudinfo/loader/loader.go
+++ b/internal/app/cloudinfo/loader/loader.go
@@ -359,10 +359,15 @@ func (sl *storeCloudInfoLoader) LoadVms(provider string, service string, region 
 		for _, sourceVM := range sourceVMs {
 
 			for _, excludeVM := range region.Data.Vms.Data {
-				if excludeVM.Type != sourceVM.Type {
-					filteredVMs = append(filteredVMs, sourceVM)
+				if sourceVM.Type == excludeVM.Type {
+					// skip excluded values
+					continue
 				}
+
+				// only append values that are not excluded
+				filteredVMs = append(filteredVMs, sourceVM)
 			}
+
 		}
 
 		sl.store.StoreVm(provider, service, region.Id, filteredVMs)
@@ -383,10 +388,13 @@ func (sl *storeCloudInfoLoader) LoadVms(provider string, service string, region 
 		filteredVMs := make([]types.VMInfo, 0, len(sourceVMs))
 		for _, sourceVM := range sourceVMs {
 
-			for _, excludeVM := range region.Data.Vms.Data {
-				if excludeVM.Type == sourceVM.Type {
-					filteredVMs = append(filteredVMs, sourceVM)
+			for _, includeVM := range region.Data.Vms.Data {
+				if sourceVM.Type != includeVM.Type {
+					continue
 				}
+
+				// only append included values
+				filteredVMs = append(filteredVMs, sourceVM)
 			}
 		}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   |yes
| License         | Apache 2.0


### What's in this PR?
Fixed loading of VMs in case there are no VMs specified in the configuration file

### Why?
"Inherited" VMs were not stored for the PKE service



- [X] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [X] Logging code meets the guideline (TODO)
- [X] User guide and development docs updated (if needed)
