### PR TITLE
fix name filter while describing eks images

### DIFF
--- a/internal/cloudinfo/providers/amazon/image_helper.go
+++ b/internal/cloudinfo/providers/amazon/image_helper.go
@@ -31,9 +31,9 @@ const (
 )
 
 func getEKSDescribeImagesInput(kubernetesVersion string, GPUs bool) *ec2.DescribeImagesInput {
-	nameFilter := fmt.Sprintf(eksImageNameFormat, kubernetesVersion, eksImageNamePrefix)
+	nameFilter := fmt.Sprintf(eksImageNameFormat, eksImageNamePrefix, kubernetesVersion)
 	if GPUs {
-		nameFilter = fmt.Sprintf(eksImageNameFormat, kubernetesVersion, eksGPUImageNamePrefix)
+		nameFilter = fmt.Sprintf(eksImageNameFormat, eksGPUImageNamePrefix, kubernetesVersion)
 	}
 
 	describeImagesInput := ec2.DescribeImagesInput{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
fixes the name filter when describing images

### Why?
due to the invalid filter no images were found while scraping


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline

fixes #287 
