### PR TITLE
bound amazon credential envVars into the app config

### DIFF
--- a/cmd/cloudinfo/config.go
+++ b/cmd/cloudinfo/config.go
@@ -263,8 +263,8 @@ func configure(v *viper.Viper, p *pflag.FlagSet) {
 	p.Bool("provider-amazon", false, "enable amazon provider")
 	_ = v.BindPFlag("provider.amazon.enabled", p.Lookup("provider-amazon"))
 
-	_ = v.BindEnv("provider.amazon.accessKey")
-	_ = v.BindEnv("provider.amazon.secretKey")
+	_ = v.BindEnv("provider.amazon.accessKey", "AWS_ACCESS_KEY_ID")
+	_ = v.BindEnv("provider.amazon.secretKey", "AWS_SECRET_ACCESS_KEY")
 	_ = v.BindEnv("provider.amazon.sharedCredentialsFile")
 	_ = v.BindEnv("provider.amazon.profile")
 	v.SetDefault("provider.amazon.prometheusAddress", "")


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #295
| License         | Apache 2.0


### What's in this PR?
AWS credentials are bound from the env

### Why?
AWS credentials specified as env vars wer not taken into account while configuring the app
