### PR TITLE
Remove EKS version 1.13 from GetServiceImages

### DIFF
--- a/internal/cloudinfo/providers/amazon/cloudinfo.go
+++ b/internal/cloudinfo/providers/amazon/cloudinfo.go
@@ -552,7 +552,7 @@ func (e *Ec2Infoer) GetServiceImages(service, region string) ([]types.Image, err
 	serviceImages := make([]types.Image, 0)
 	switch service {
 	case svcEks:
-		for _, k8sVersion := range []string{"1.13", "1.14", "1.15"} {
+		for _, k8sVersion := range []string{"1.14", "1.15"} {
 
 			gpuImages, err := e.ec2Describer(region).DescribeImages(getEKSDescribeImagesInput(k8sVersion, true))
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #323 
| License         | Apache 2.0


### What's in this PR?
Remove EKS version 1.13 from GetServiceImages function as well.