### PR TITLE
Check product store is ready on startup

### DIFF
--- a/cmd/cloudinfo/main.go
+++ b/cmd/cloudinfo/main.go
@@ -170,6 +170,9 @@ func main() {
 	// use the configured store implementation
 	cloudInfoStore := cistore.NewCloudInfoStore(config.Store, cloudInfoLogger)
 	defer cloudInfoStore.Close()
+	if !cloudInfoStore.Ready() {
+		emperror.Panic(errors.New("configured product store not available"))
+	}
 
 	infoers, providers, err := loadInfoers(config, cloudInfoLogger)
 	emperror.Panic(err)

--- a/internal/app/cloudinfo/cistore/cassandra.go
+++ b/internal/app/cloudinfo/cistore/cassandra.go
@@ -45,6 +45,16 @@ func NewCassandraProductStore(config cassandra.Config, logger cloudinfo.Logger) 
 	}
 }
 
+func (cps *cassandraProductStore) Ready() bool {
+	err := cps.initSession()
+	if err != nil {
+		cps.log.Error("failure checking cassandra ready", map[string]interface{}{"error": err})
+		return false
+	}
+	cps.log.Debug("casandra product store ready")
+	return true
+}
+
 func (cps *cassandraProductStore) StoreRegions(provider, service string, val map[string]string) {
 	cps.set(cps.getKey(cloudinfo.RegionKeyTemplate, provider, service), val)
 }

--- a/internal/app/cloudinfo/cistore/go-cache.go
+++ b/internal/app/cloudinfo/cistore/go-cache.go
@@ -34,6 +34,10 @@ type cacheProductStore struct {
 	log        cloudinfo.Logger
 }
 
+func (cis *cacheProductStore) Ready() bool {
+	return true
+}
+
 func (cis *cacheProductStore) DeleteRegions(provider, service string) {
 	cis.Delete(cis.getKey(cloudinfo.RegionKeyTemplate, provider, service))
 }

--- a/internal/app/cloudinfo/cistore/redis.go
+++ b/internal/app/cloudinfo/cistore/redis.go
@@ -31,6 +31,23 @@ type redisProductStore struct {
 	log  cloudinfo.Logger
 }
 
+func (rps *redisProductStore) Ready() bool {
+	conn := rps.pool.Get()
+	defer conn.Close()
+
+	reply, err := conn.Do("PING")
+	if err != nil {
+		rps.log.Error("failure checking redis ready", map[string]interface{}{"error": err})
+		return false
+	}
+	if reply != "PONG" {
+		rps.log.Error("redis PING returned unexpected value")
+		return false
+	}
+	rps.log.Debug("redis product store ready")
+	return true
+}
+
 func (rps *redisProductStore) DeleteRegions(provider, service string) {
 	rps.delete(rps.getKey(cloudinfo.RegionKeyTemplate, provider, service))
 }

--- a/internal/cloudinfo/store.go
+++ b/internal/cloudinfo/store.go
@@ -48,6 +48,8 @@ const (
 
 // Storage operations for cloud information
 type CloudInfoStore interface {
+	Ready() bool
+
 	StoreRegions(provider, service string, val map[string]string)
 	GetRegions(provider, service string) (map[string]string, bool)
 	DeleteRegions(provider, service string)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #336 
| License         | Apache 2.0

### What's in this PR?
Introduces a Ready function to the CloudInfoStore interface and checks on start that this returns true for the configured product store, failing with an appropriate message.

Implements Ready for Cassandra (check a session can be created) and Redis (using the PING operation) to check the store is ready. For in-memory just returns true.

### Additional context
Tested by killing Redis then starting cloudinfo - can see it fail as expected:

```
INFO[0000] starting application                          application=cloudinfo arch=amd64 build_date="2020-06-23T12:58:36+0100" commit_hash=83911af compiler=gc environment=development go_version=go1.14 os=darwin version=fail-on-store-error
INFO[0000] using Redis as product store                  application=cloudinfo environment=development
ERRO[0000] failed to set key to value                    application=cloudinfo cistore=redis environment=development key=/banzaicloud.com/cloudinfo/ready value="map[ready:true]"
ERRO[0000] configured product store not available        application=cloudinfo environment=development
```

Works normally if Redis is up and running.

Same test performed for Cassandra.

### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)

### To Do
- [x] I'd appreciate it if someone can verify that this approach (i.e. stopping the cloudinfo process from starting rather than a pause/wait loop for the store to become available) is the best solution.
- [x] Sanity check that cassandra works correctly - I've not been able to get the cassandra container to start correctly here so haven't been able to test that (`make up` creates the container but it then stops with no output) - **now tested successfully**