### PR TITLE
circleci: fix docker image build when branch name contains `/`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,7 @@ workflows:
                     name: Build docker image
                     deploy: false
                     image: banzaicloud/cloudinfo
-                    tag: $CIRCLE_BRANCH
+                    tag: ${CIRCLE_BRANCH//\//_}
                     filters:
                         branches:
                             ignore: master


### PR DESCRIPTION
.