### PR TITLE
Bump redis chart version

### DIFF
--- a/charts/cloudinfo/Chart.yaml
+++ b/charts/cloudinfo/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 description: Cloud instance type and price information as a service
 name: cloudinfo
-version: 0.7.1
+version: 0.7.2
 
-appVersion: "0.9.15"
+appVersion: "0.12.1"
 
 home: https://banzaicloud.com
 

--- a/charts/cloudinfo/requirements.lock
+++ b/charts/cloudinfo/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 9.1.8
-digest: sha256:ea7cf05aa2d82562c8b35bf601cefb6abcceafc6c3f7a2c4e42dbca99bfa213a
-generated: "2019-09-11T12:40:59.281824+02:00"
+  version: 10.5.7
+digest: sha256:e54f24eee5ad2dd221127948de81286beb2343c5d13120022d6dbf69879597d1
+generated: "2020-07-06T10:16:11.323191+02:00"

--- a/charts/cloudinfo/requirements.yaml
+++ b/charts/cloudinfo/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: redis
-    version: 9.1.8
+    version: 10.5.7
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: redis.enabled

--- a/charts/cloudinfo/values.yaml
+++ b/charts/cloudinfo/values.yaml
@@ -5,7 +5,7 @@ serviceAccountName: ""
 
 image:
   repository: banzaicloud/cloudinfo
-  tag: 0.9.15
+  tag: 0.12.1
   pullPolicy: IfNotPresent
 
 frontend:


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
- Bump redis chart version to 10.5.7 (kind: statefulset in version apps/v1 instead of apps/v1beta2) 
- Update cloudinfo version