### PR TITLE
Filter PKE AWS AMI image owners

### DIFF
--- a/internal/cloudinfo/providers/amazon/image_helper.go
+++ b/internal/cloudinfo/providers/amazon/image_helper.go
@@ -66,7 +66,15 @@ func getPKEDescribeImagesInput() *ec2.DescribeImagesInput {
 				Name:   aws.String(fmt.Sprintf("tag:%s", tagPKEVersion)),
 				Values: []*string{aws.String("*")},
 			},
+			{
+				Name:   aws.String("is-public"),
+				Values: []*string{aws.String("true")},
+			},
 		},
+		Owners: aws.StringSlice([]string{
+			"161831738826", // banzaicloud
+			"self",         // account used for cloudinfo scraping
+		}),
 	}
 	return &describeImagesInput
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Filter listed PKE AMI images to be public and owned either by the account used for cloudinfo amazon scraping, or banzaicloud.