### PR TITLE
Improve Azure region categorisation into continents.

### DIFF
--- a/internal/cloudinfo/cloudinfo.go
+++ b/internal/cloudinfo/cloudinfo.go
@@ -208,9 +208,10 @@ func getContinent(region string) string {
 		return types.ContinentAustralia
 	case checkContinent(region, []string{"cn-", "ap-", "me-", "asia", "japan", "india", "korea"}),
 		strings.HasPrefix(region, "sgp"),
-		strings.HasPrefix(region, "blr"):
+		strings.HasPrefix(region, "blr"),
+		strings.HasPrefix(region, "uae"):
 		return types.ContinentAsia
-	case checkContinent(region, []string{"eu", "uk", "france"}),
+	case checkContinent(region, []string{"eu", "uk", "france", "switzerland", "germany", "norway"}),
 		strings.HasPrefix(region, "ams"),
 		strings.HasPrefix(region, "lon"),
 		strings.HasPrefix(region, "fra"):
@@ -222,7 +223,7 @@ func getContinent(region string) string {
 		return types.ContinentNorthAmerica
 	case checkContinent(region, []string{"southamerica", "brazil", "sa-"}):
 		return types.ContinentSouthAmerica
-	case checkContinent(region, []string{"africa"}):
+	case checkContinent(region, []string{"africa", "af-"}):
 		return types.ContinentAfrica
 	default:
 		return "unknown"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | Fixes #353
| License         | Apache 2.0


### What's in this PR?
Add extra matches to the continent logic to categorise several Azure regions plus af-south-1 for Amazon.

### Additional context
Tested by running with Azure, AWS and GCP enabled, none now return any regions in the 'unknown' continent.

### Checklist
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~~[ ] User guide and development docs updated (if needed)~~
- ~~[ ] Related Helm chart(s) updated (if needed)~~
