### PR TITLE
Add support for separate pricing credentials

### DIFF
--- a/cmd/cloudinfo/config.go
+++ b/cmd/cloudinfo/config.go
@@ -270,10 +270,19 @@ func configure(v *viper.Viper, p *pflag.FlagSet) {
 	p.Bool("provider-amazon", false, "enable amazon provider")
 	_ = v.BindPFlag("provider.amazon.enabled", p.Lookup("provider-amazon"))
 
+	const defaultAmazonPricingRegion = "us-east-1"
+
 	_ = v.BindEnv("provider.amazon.accessKey", "AWS_ACCESS_KEY_ID")
 	_ = v.BindEnv("provider.amazon.secretKey", "AWS_SECRET_ACCESS_KEY")
+	_ = v.BindEnv("provider.amazon.sessionToken", "AWS_SESSION_TOKEN")
 	_ = v.BindEnv("provider.amazon.sharedCredentialsFile")
-	_ = v.BindEnv("provider.amazon.profile")
+	_ = v.BindEnv("provider.amazon.profile", "AWS_PROFILE")
+	v.SetDefault("provider.amazon.pricing.region", defaultAmazonPricingRegion)
+	_ = v.BindEnv("provider.amazon.pricing.accessKey")
+	_ = v.BindEnv("provider.amazon.pricing.secretKey")
+	_ = v.BindEnv("provider.amazon.pricing.sessionToken")
+	_ = v.BindEnv("provider.amazon.pricing.sharedCredentialsFile")
+	_ = v.BindEnv("provider.amazon.pricing.profile")
 	v.SetDefault("provider.amazon.prometheusAddress", "")
 	v.SetDefault("provider.amazon.prometheusQuery", "avg_over_time(aws_spot_current_price{region=\"%s\", product_description=\"Linux/UNIX\"}[1w])")
 

--- a/config.toml.dist
+++ b/config.toml.dist
@@ -42,7 +42,7 @@ enabled = false
 # secretKey = ""
 
 # Shared credentials
-# sharedCredentialsFile = ""
+# sharedCredentialsFile = ""
 # profile = ""
 
 # http address of a Prometheus instance that has AWS spot price metrics via banzaicloud/spot-price-exporter.
@@ -51,6 +51,22 @@ prometheusAddress = ""
 
 # advanced configuration: change the query used to query spot price info from Prometheus.
 prometheusQuery = "avg_over_time(aws_spot_current_price{region=\"%s\", product_description=\"Linux/UNIX\"}[1w])"
+
+# Amazon pricing API credentials (optional)
+# Falls back to the primary credentials.
+[provider.amazon.pricing]
+
+# See available regions in the documentation:
+# https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/using-pelong.html
+# region = "us-east-1"
+
+# Static credentials
+# accessKey = ""
+# secretKey = ""
+
+# Shared credentials
+# sharedCredentialsFile = ""
+# profile = ""
 
 [provider.google]
 enabled = false


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #350
| License         | Apache 2.0


### What's in this PR?
Support for separate pricing credentials


### Why?

The AWS Pricing API used for getting price information
about is only available in a small number of regions.

The primary account used for other resources
might not have access to those regions (eg. GovCloud).

For those cases, the price scraping client can
receive a different set of credentials.
