### PR TITLE
ci: upgrade helm orb to 0.0.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-    helm: banzaicloud/helm@0.0.7
+    helm: banzaicloud/helm@0.0.8
     docker: circleci/docker@0.5.13
 
 executors:


### PR DESCRIPTION
Fixes missing incubator repo and upgrades helm to v3.4.1.
