### PR TITLE
Fixed CI/GHA licensei cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,9 +49,9 @@ jobs:
           path: .licensei.cache
           key: licensei-v1-${{ steps.set-git-refname.outputs.git_refname }}-${{ hashFiles('go.sum') }}
           restore-keys: |
-            - licensei-v1-${{ steps.set-git-refname.outputs.git_refname }}
-            - licensei-v1-master
-            - licensei-v1
+            licensei-v1-${{ steps.set-git-refname.outputs.git_refname }}
+            licensei-v1-master
+            licensei-v1
 
       - name: Download license information for dependencies
         env:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixed CI/GHA licensei cache.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

It was broken.
I made a mistake by specifying the restore keys in a YAML array, then realized caching takes a multiline string, added the vertical pipe, but left the array dash prefixes in, messing up the restore keys on not hitting the full key.
(And it took me a while to notice it after I ruled out a couple other possibilities.)

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

[Here](https://github.com/banzaicloud/cloudinfo/runs/3126392643?check_suite_focus=true#step:6:17) is an example of the working restore key from this branch on a branch CI run.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
