### PR TITLE
Removed unsupported k8s versions

### DIFF
--- a/configs/amazon-service-data.yaml
+++ b/configs/amazon-service-data.yaml
@@ -15,8 +15,6 @@ regions:
                 data:
                     -   location: eu-north-1
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -91,8 +89,6 @@ regions:
                 data:
                     -   location: ap-northeast-2
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -167,8 +163,6 @@ regions:
                 data:
                     -   location: sa-east-1
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -243,8 +237,6 @@ regions:
                 data:
                     -   location: us-west-2
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -319,8 +311,6 @@ regions:
                 data:
                     -   location: eu-central-1
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -395,8 +385,6 @@ regions:
                 data:
                     -   location: ca-central-1
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -471,8 +459,6 @@ regions:
                 data:
                     -   location: ap-south-1
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -547,8 +533,6 @@ regions:
                 data:
                     -   location: us-west-1
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -623,8 +607,6 @@ regions:
                 data:
                     -   location: ap-southeast-1
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -699,8 +681,6 @@ regions:
                 data:
                     -   location: eu-west-1
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -775,8 +755,6 @@ regions:
                 data:
                     -   location: us-east-2
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -851,8 +829,6 @@ regions:
                 data:
                     -   location: us-east-1
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -927,8 +903,6 @@ regions:
                 data:
                     -   location: ap-northeast-1
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -1003,8 +977,6 @@ regions:
                 data:
                     -   location: eu-west-2
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -1079,8 +1051,6 @@ regions:
                 data:
                     -   location: ap-southeast-2
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -1155,8 +1125,6 @@ regions:
                 data:
                     -   location: eu-west-3
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -1233,8 +1201,6 @@ regions:
                 data:
                     -   location: us-gov-east-1
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -1310,8 +1276,6 @@ regions:
                 data:
                     -   location: us-gov-west-1
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0

--- a/configs/azure-service-data.yaml
+++ b/configs/azure-service-data.yaml
@@ -15,8 +15,6 @@ regions:
                 data:
                     -   location: centralus
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -35,8 +33,6 @@ regions:
                 data:
                     -   location: eastus
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -55,8 +51,6 @@ regions:
                 data:
                     -   location: eastus2
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -75,8 +69,6 @@ regions:
                 data:
                     -   location: westus2
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -95,8 +87,6 @@ regions:
                 data:
                     -   location: francecentral
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -115,8 +105,6 @@ regions:
                 data:
                     -   location: northeurope
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -135,8 +123,6 @@ regions:
                 data:
                     -   location: uksouth
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -155,8 +141,6 @@ regions:
                 data:
                     -   location: westeurope
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -175,8 +159,6 @@ regions:
                 data:
                     -   location: japaneast
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -195,8 +177,6 @@ regions:
                 data:
                     -   location: southeastasia
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -215,8 +195,6 @@ regions:
                 data:
                     -   location: australiasoutheast
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -235,8 +213,6 @@ regions:
                 data:
                     -   location: eastasia
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -255,8 +231,6 @@ regions:
                 data:
                     -   location: canadacentral
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -275,8 +249,6 @@ regions:
                 data:
                     -   location: canadaeast
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -295,8 +267,6 @@ regions:
                 data:
                     -   location: koreasouth
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -315,8 +285,6 @@ regions:
                 data:
                     -   location: japanwest
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -335,8 +303,6 @@ regions:
                 data:
                     -   location: southindia
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -355,8 +321,6 @@ regions:
                 data:
                     -   location: westus
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -375,8 +339,6 @@ regions:
                 data:
                     -   location: southcentralus
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -395,8 +357,6 @@ regions:
                 data:
                     -   location: northcentralus
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -415,8 +375,6 @@ regions:
                 data:
                     -   location: australiaeast
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -435,8 +393,6 @@ regions:
                 data:
                     -   location: centralindia
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -455,8 +411,6 @@ regions:
                 data:
                     -   location: ukwest
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0
@@ -475,8 +429,6 @@ regions:
                 data:
                     -   location: koreacentral
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0

--- a/configs/vsphere-service-data.yaml
+++ b/configs/vsphere-service-data.yaml
@@ -14,8 +14,6 @@ regions:
                 data:
                     -   location: default
                         versions:
-                            - 1.17.17
-                            - 1.18.18
                             - 1.19.10
                             - 1.20.6
                             - 1.21.0

--- a/internal/cloudinfo/providers/amazon/cloudinfo.go
+++ b/internal/cloudinfo/providers/amazon/cloudinfo.go
@@ -553,7 +553,7 @@ func (e *Ec2Infoer) GetServiceImages(service, region string) ([]types.Image, err
 	serviceImages := make([]types.Image, 0)
 	switch service {
 	case svcEks:
-		for _, k8sVersion := range []string{"1.16", "1.17", "1.18", "1.19", "1.20", "1.21"} {
+		for _, k8sVersion := range []string{"1.19", "1.20", "1.21"} {
 			gpuImages, err := e.ec2Describer(region).DescribeImages(getEKSDescribeImagesInput(k8sVersion, true))
 			if err != nil {
 				return nil, err
@@ -617,7 +617,7 @@ func (e *Ec2Infoer) GetServiceProducts(region, service string) ([]types.ProductD
 func (e *Ec2Infoer) GetVersions(service, region string) ([]types.LocationVersion, error) {
 	switch service {
 	case svcEks:
-		return []types.LocationVersion{types.NewLocationVersion(region, []string{"1.16.15", "1.17.17", "1.18.16", "1.19.8", "1.20.7", "1.21.2"}, "1.18.16")}, nil
+		return []types.LocationVersion{types.NewLocationVersion(region, []string{"1.19.8", "1.20.7", "1.21.2"}, "1.19.8")}, nil
 	default:
 		return []types.LocationVersion{}, nil
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | yes
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Dropping support for old Kubernetes versions.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Converging to support the latest versions of Kubernetes, some upgrades made k8s versions older than 1.19 deprecated.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Tested locally

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~