### PR TITLE
Attempt fixing the GHA container image access

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -72,7 +72,7 @@ jobs:
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}
             org.opencontainers.image.url=${{ github.event.repository.html_url }}
-            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.version=${{ steps.tags.outputs.version }}
             org.opencontainers.image.created=${{ steps.tags.outputs.build_date }}
             org.opencontainers.image.revision=${{ github.sha }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Setting the container label org.opencontainers.image.source to the HTTPS URL of the repository instead of the SSH URL of it.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To try and fix the GHA access to the ghcr.io/banzaicloud/cloudinfo container repository and pacakges.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

For some reason GHA lost access to the ghcr.io container registry somewhere in the past.

There is a confirmed fix to add GHA write access to the cloudinfo repository, at the ghcr.io package settings page, but the
org.opencontainers.image.source label should do the same when configured correctly.

For now I'm trying to set it to the HTML URL (HTTPS) instead of the clone URL (SSH).

If this doesn't work we are going to revert it and settle for the manual write access setting.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~
