### PR TITLE
Filter for `gpu` and `cr` params

### DIFF
--- a/internal/app/cloudinfo/api/handlers.go
+++ b/internal/app/cloudinfo/api/handlers.go
@@ -449,6 +449,9 @@ func (r *RouteHandler) getImages() gin.HandlerFunc {
 				if queryParams.Os != "" && queryParams.Os != image.Tags["os-type"] {
 					continue
 				}
+				if queryParams.Cr != "" && queryParams.Cr != image.Tags["cr"] {
+					continue
+				}
 				if queryParams.PkeVersion != "" && queryParams.PkeVersion != image.Tags["pke-version"] {
 					continue
 				}

--- a/internal/app/cloudinfo/api/handlers.go
+++ b/internal/app/cloudinfo/api/handlers.go
@@ -439,7 +439,10 @@ func (r *RouteHandler) getImages() gin.HandlerFunc {
 				if queryParams.Version != "" && queryParams.Version != image.Version {
 					continue
 				}
-				if queryParams.Gpu != "" && !image.GpuAvailable {
+				if queryParams.Gpu == "true" && !image.GpuAvailable {
+					continue
+				}
+				if queryParams.Gpu == "false" && image.GpuAvailable {
 					continue
 				}
 				// todo possibly add filtering by all tags (generic)

--- a/internal/app/cloudinfo/api/types.go
+++ b/internal/app/cloudinfo/api/types.go
@@ -55,6 +55,8 @@ type GetImagesQueryParams struct {
 	// in:query
 	Gpu string `json:"gpu"`
 	// in:query
+	Cr string `json:"cr"`
+	// in:query
 	Version string `json:"version"`
 	// in:query
 	Os string `json:"os,omitempty"`


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixed image filtering for `gpu` tag, also added filtering for `cr` (container runtime) image tag that was introduced with PKE 0.9.3.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The correct images to be returned on request with these params.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Tested locally.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~